### PR TITLE
feat: 更细腻的nice的控制

### DIFF
--- a/src/linear.js
+++ b/src/linear.js
@@ -3,6 +3,7 @@
  * @author dxq613@gmail.com
  */
 const isNil = require('@antv/util/src/type/isNil');
+const isNumber = require('@antv/util/src/type/isNumber');
 const each = require('@antv/util/src/each');
 
 const Base = require('./base');
@@ -123,6 +124,11 @@ class Linear extends Base {
     const self = this;
     const calTicks = self.calculateTicks();
     if (self.nice) { // 如果需要优化显示的tick
+      if (isNumber(self.nice)) {
+        const [lastTick] = calTicks.slice(-1)
+        const upperBoundaryTick = lastTick * (1 + self.nice)
+        calTicks.push(upperBoundaryTick)
+      }
       self.ticks = calTicks;
       self.min = calTicks[0];
       self.max = calTicks[calTicks.length - 1];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

提交PR的动机是，g2中如果y轴如果`nice=true`，会自动计算y的最大最小值，并且给坐标轴的两端留出一些空间。然而如果我希望控制留空大小的话，还是没有办法。

我在添加复杂的背景的时候遇到了一些问题，具体讨论在此 https://github.com/antvis/g2/issues/705

我看了几个解决方案，最终觉得可能在scale包里面做一些扩展，是简单的。希望开发团队可以参与讨论，谢谢。