### PR TITLE
fix: 修复计算精度有问题的scale，陷入死循环的问题

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
   apt:
     packages:
       - xvfb
+      - libgconf-2-4
 
 install:
   - export DISPLAY=':99.0'

--- a/src/auto/number.js
+++ b/src/auto/number.js
@@ -40,7 +40,7 @@ module.exports = function(info) {
   if (isNil(max)) {
     max = 0;
   }
-  if (Math.max(max - min) < EPS) {
+  if (Math.abs(max - min) < EPS) {
     if (min === 0) {
       max = 1;
     } else {

--- a/src/auto/number.js
+++ b/src/auto/number.js
@@ -11,6 +11,7 @@ const MIN_COUNT = 5;
 const MAX_COUNT = 7;
 const SNAP_COUNT_ARRAY = [ 0, 1, 1.2, 1.5, 1.6, 2, 2.2, 2.4, 2.5, 3, 4, 5, 6, 7.5, 8, 10 ];
 const SNAP_ARRAY = [ 0, 1, 2, 4, 5, 10 ];
+const EPS = 1e-12;
 
 module.exports = function(info) {
   let min = info.min;
@@ -39,7 +40,7 @@ module.exports = function(info) {
   if (isNil(max)) {
     max = 0;
   }
-  if (max === min) {
+  if (Math.max(max - min) < EPS) {
     if (min === 0) {
       max = 1;
     } else {
@@ -95,13 +96,19 @@ module.exports = function(info) {
       minTick = avgTick - (sideCount + 1) * interval;
     }
 
-    while (maxTick < max) { // 保证计算出来的刻度最大值 maxTick 不小于数据最大值 max
+    let prevMaxTick = null;
+    // 如果减去intervl, fixBase后，新的minTick没有大于之前的值，就退出，防止死循环
+    while (maxTick < max && (prevMaxTick === null || maxTick > prevMaxTick)) { // 保证计算出来的刻度最大值 maxTick 不小于数据最大值 max
+      prevMaxTick = maxTick;
       maxTick = AutoUtil.fixedBase(maxTick + interval, interval);
     }
-    while (minTick > min) { // 保证计算出来的刻度最小值 minTick 不小于数据最大值 min
+
+    let prevMinTick = null;
+    // 如果减去intervl, fixBase后，新的minTick没有小于之前的值，就退出，防止死循环
+    while (minTick > min && (prevMinTick === null || minTick < prevMinTick)) { // 保证计算出来的刻度最小值 minTick 不小于数据最大值 min
+      prevMinTick = minTick;
       minTick = AutoUtil.fixedBase(minTick - interval, interval); // 防止超常浮点数计算问题
     }
-
     max = maxTick;
     min = minTick;
   }

--- a/src/auto/util.js
+++ b/src/auto/util.js
@@ -83,6 +83,7 @@ function arrayCeiling(values, value) {
   return rst;
 }
 
+
 const Util = {
   // 获取逼近的数值
   snapFactorTo(v, arr, snapType) { // 假设 v = -512,isFloor = true
@@ -177,10 +178,14 @@ const Util = {
   fixedBase(v, base) {
     const str = base.toString();
     const index = str.indexOf('.');
-    if (index === -1) {
+    const indexOfExp = str.indexOf('e-');
+
+    // 判断是否带小数点，1.000001 1.23e-9
+    if (index < 0 && indexOfExp < 0) {
+      // base为整数
       return Math.round(v);
     }
-    let length = str.substr(index + 1).length;
+    let length = indexOfExp >= 0 ? parseInt(str.substr(indexOfExp + 2), 10) : str.substr(index + 1).length;
     if (length > 20) {
       length = 20;
     }

--- a/test/unit/auto/util-spec.js
+++ b/test/unit/auto/util-spec.js
@@ -74,4 +74,14 @@ describe('test util', () => {
     expect(Util.snapMultiple(23, 5)).to.be.equal(25);
   });
 
+  it('fix base', () => {
+    expect(Util.fixedBase(1.234, 0.23)).to.be.equal(1.23);
+    expect(Util.fixedBase(1.234, 23.23)).to.be.equal(1.23);
+    expect(Util.fixedBase(1.234, 1e-5)).to.be.equal(1.234);
+
+    expect(Util.fixedBase(1.2345678, 0.23)).to.be.equal(1.23);
+    expect(Util.fixedBase(1.2345678, 23.23)).to.be.equal(1.23);
+    expect(Util.fixedBase(1.2345678, 1e-5)).to.be.equal(1.23457);
+  });
+
 });

--- a/test/unit/number-spec.js
+++ b/test/unit/number-spec.js
@@ -235,3 +235,16 @@ describe('scale linear: declare tickInterval.', () => {
     expect(ticks).eql([ 15, 30, 45, 60, 75, 90 ]);
   });
 });
+
+describe('scale linear: min and max are numbers which precision is 15 and specify tickCount ', () => {
+  const scale = Scale.linear({
+    min: 0.999999999999997,
+    max: 1.000000000000033,
+    tickCount: 5
+  });
+
+  it('ticks', () => {
+    const ticks = scale.ticks;
+    expect(ticks).eql([ 1 ]);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

修复如下scale计算的时候，会陷入死循环的问题
```
const scale = Scale.linear({
    min: 0.999999999999997,
    max: 1.000000000000033,
    tickCount: 5
  });
```