### PR TITLE
fix: strictly respect min/max setting

### DIFF
--- a/__tests__/unit/linear-spec.js
+++ b/__tests__/unit/linear-spec.js
@@ -3,8 +3,7 @@ import Linear from '../../src/linear';
 
 describe('linear scale', () => {
   const scale = new Linear({
-    min: 0,
-    max: 100,
+    values: [0, 100],
     formatter(val) {
       return val + '元';
     },
@@ -47,8 +46,7 @@ describe('linear scale', () => {
 
   it('change func', () => {
     scale.change({
-      min: 10,
-      max: 110,
+      values: [10, 110],
       nice: false,
     });
     expect(scale.scale(60)).to.be.equal(0.5);
@@ -57,7 +55,7 @@ describe('linear scale', () => {
 
 describe('linear scale for c(0, 10, 100)', () => {
   const scale = new Linear({
-    values: [ 0, 10, 100 ],
+    values: [0, 10, 100],
   });
 
   it('config', () => {
@@ -77,9 +75,8 @@ describe('linear scale for c(0, 10, 100)', () => {
 
 describe('linear scale for specified range', () => {
   const scale = new Linear({
-    min: 0,
-    max: 100,
-    range: [ 0, 1000 ],
+    values: [0, 100],
+    range: [0, 1000],
   });
 
   it('scale func', () => {
@@ -97,26 +94,23 @@ describe('linear scale for specified range', () => {
 
 describe('linear scale multiple times', () => {
   const scale = new Linear({
-    min: 21,
-    max: 145,
+    values: [21, 145],
   });
 
   it('1st time', () => {
-    expect(scale.ticks).to.be.eql([ 0, 50, 100, 150 ]);
+    expect(scale.ticks).to.be.eql([0, 50, 100, 150]);
   });
 
   it('2nd time', () => {
-    scale.change({ min: 0 });
-    expect(scale.ticks).to.be.eql([ 0, 50, 100, 150 ]);
+    scale.change({ values: [0, 145] });
+    expect(scale.ticks).to.be.eql([0, 50, 100, 150]);
   });
 });
 
 describe('linear scale for invalid min and max', () => {
   it('min > max', () => {
     const scale = new Linear({
-      min: 100,
-      max: 0,
-      values: [ 10, 20, 30 ],
+      values: [10, 20, 30],
     });
     expect(scale.min).to.equal(10);
     expect(scale.max).to.equal(30);
@@ -124,19 +118,46 @@ describe('linear scale for invalid min and max', () => {
 
   it('min = max', () => {
     const scale = new Linear({
-      values: [ 10 ],
+      values: [10],
     });
-    expect(scale.ticks).to.eql([ 10 ]);
+    expect(scale.ticks).to.eql([10]);
   });
 });
 
 describe('linear scale with minInterval', () => {
   it('c(0, 62), minInterval = 14', () => {
     const scale = new Linear({
-      min: 0,
-      max: 62,
+      values: [0, 62],
       minTickInterval: 14,
     });
-    expect(scale.ticks).to.eql([ 0, 14, 28, 42, 56, 70 ]);
+    expect(scale.ticks).to.eql([0, 14, 28, 42, 56, 70]);
+  });
+});
+
+describe('linear scale with min/max', () => {
+  it('c(0,100), min = 5', () => {
+    const scale = new Linear({
+      values: [0, 100],
+      min: 5,
+    });
+    expect(scale.min).to.equal(5);
+  });
+
+  it('c(0,100), max = 95', () => {
+    const scale = new Linear({
+      values: [0, 100],
+      max: 95,
+    });
+    expect(scale.max).to.equal(95);
+  });
+
+  it('c(0,100), max = 95', () => {
+    const scale = new Linear({
+      values: [0, 100],
+      min: 5,
+      max: 95,
+    });
+    expect(scale.min).to.equal(5);
+    expect(scale.max).to.equal(95);
   });
 });

--- a/src/base.ts
+++ b/src/base.ts
@@ -89,6 +89,8 @@ export default abstract class Scale {
 
   /** 重新初始化 */
   public change(cfg: ScaleConfig) {
+    delete this.min;
+    delete this.max;
     this.constructor(_.assign(this.__cfg__, cfg));
   }
 

--- a/src/linear-log.ts
+++ b/src/linear-log.ts
@@ -32,7 +32,6 @@ export default class Log extends Linear {
   }
 
   protected _init() {
-    this._setDomain();
     // todo log breaks要优化
     this.ticks = this._setTicks();
     // 不兼容处理定义域包含0的情况

--- a/src/linear-pow.ts
+++ b/src/linear-pow.ts
@@ -15,7 +15,6 @@ export default class Pow extends Linear {
   }
 
   protected _init() {
-    this._setDomain();
     // todo pow breaks要优化
     this.ticks = this._setTicks();
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [X] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

用户如果设置了min/max，就严格遵守设置的min/max， 如下面图示：
主要逻辑是先使用用户设置的min/max和数据范围中的range范围去计算ticks，计算完成后，如果有用户设置的min/max，则使用用户设置的min/max并调整ticks；否则则按照是否有nice，去设置min/max

没有设置min/max时：
![image](https://user-images.githubusercontent.com/1142242/64517094-3bf87c00-d322-11e9-8983-882a523be37f.png)

设置min为500，原来效果为：
![image](https://user-images.githubusercontent.com/1142242/64517145-56325a00-d322-11e9-9d53-ea902b31e9ac.png)

修改后的效果：
![image](https://user-images.githubusercontent.com/1142242/64515270-d951b100-d31e-11e9-9e40-0abc9d768bb3.png)

