### PR TITLE
fix: category scale 在做 scale 时，对超出范围的数据不返还 NaN

### DIFF
--- a/src/category/base.ts
+++ b/src/category/base.ts
@@ -20,9 +20,9 @@ class Category extends Base {
   public scale(value: any): number {
     const order = this.translate(value);
     // 分类数据允许 0.5 范围内调整
-    if (order < this.min - 0.5 || order > this.max + 0.5) {
-      return NaN;
-    }
+    // if (order < this.min - 0.5 || order > this.max + 0.5) {
+    //   return NaN;
+    // }
     const percent = this.calcPercent(order, this.min, this.max);
     return this.calcValue(percent, this.rangeMin(), this.rangeMax());
   }

--- a/tests/unit/category-spec.ts
+++ b/tests/unit/category-spec.ts
@@ -166,13 +166,13 @@ describe('category min, max', () => {
   });
 
   it('set min', () => {
-    const scale = new Category({ 
+    const scale = new Category({
       values: [ 'A', 'B', 'C' ],
       min: 1
     });
     expect(scale.min).toBe(1);
     expect(scale.max).toBe(2);
-    expect(scale.scale('A')).toBe(NaN);
+    expect(scale.scale('A')).toBe(-1);
     expect(scale.scale('B')).toBe(0);
     expect(scale.scale('C')).toBe(1);
     expect(isNumberEqual(scale.scale(1.2), 0.2)).toBe(true);
@@ -185,16 +185,16 @@ describe('category min, max', () => {
   });
 
   it('set min ,max', () => {
-    const scale = new Category({ 
+    const scale = new Category({
       values: [ 'A', 'B', 'C', 'D', 'E', 'F'],
       min: 1,
       max: 3
     });
     expect(scale.min).toBe(1);
     expect(scale.max).toBe(3);
-    expect(scale.scale('A')).toBe(NaN);
+    expect(scale.scale('A')).toBe(-0.5);
     expect(scale.scale('C')).toBe(0.5);
-    expect(scale.scale('E')).toBe(NaN);
+    expect(scale.scale('E')).toBe(1.5);
     expect(scale.invert(-0.2)).toBe('B');
     expect(scale.invert(0)).toBe('B');
     expect(scale.invert(1)).toBe('D');

--- a/tests/unit/time-cat-spec.ts
+++ b/tests/unit/time-cat-spec.ts
@@ -34,7 +34,7 @@ describe('test time category scale', () => {
       values: ['2010-01-01', '2012-02-02', '2012-02-04'],
       min: 1
     });
-    expect(scale.scale('2010-01-01')).toBe(NaN);
+    expect(scale.scale('2010-01-01')).toBe(-1);
     expect(scale.scale('2012-02-02')).toBe(0);
     expect(scale.scale('2012-02-04')).toBe(1);
     expect(scale.invert(1)).toBe(toTimeStamp('2012-02-04'));


### PR DESCRIPTION
关联：https://github.com/antvis/G2/issues/2138

G2 在 dodge 后，x 会超出 scale 范围，导致图表绘制出错。