### PR TITLE
fix(extended,pretty): Math.log10 etc error on IE11

### DIFF
--- a/src/util/extended.ts
+++ b/src/util/extended.ts
@@ -1,4 +1,4 @@
-import { head, indexOf, last, map, size } from '@antv/util';
+import { head, indexOf, last, map, size, isInteger } from '@antv/util';
 
 export const DEFAULT_Q = [1, 5, 2, 2.5, 4, 3];
 
@@ -96,7 +96,7 @@ export default function extended(
   while (j < Infinity) {
     for (const q of Q) {
       const sm = simplicityMax(q, Q, j);
-      if (Number.isNaN(sm)) {
+      if (isNaN(sm)) {
         throw new Error('NaN');
       }
       if (w[0] * sm + w[1] + w[2] + w[3] < best.score) {
@@ -111,7 +111,7 @@ export default function extended(
         }
 
         const delta = (dmax - dmin) / (k + 1) / j / q;
-        let z = Math.ceil(Math.log10(delta));
+        let z = Math.ceil(Math.log(delta)/Math.log(10));
 
         while (z < Infinity) {
           const step = j * q * Math.pow(10, z);
@@ -154,12 +154,12 @@ export default function extended(
     j = j + 1;
   }
   // 步长为浮点数时处理精度
-  const toFixed = Number.isInteger(best.lstep) ? 0 : Math.ceil(Math.abs(Math.log10(best.lstep)));
+  const toFixed = isInteger(best.lstep) ? 0 : Math.ceil(Math.abs(Math.log(best.lstep)/Math.log(10)));
   const range = [];
   for (let tick = best.lmin; tick <= best.lmax; tick += best.lstep) {
     range.push(tick);
   }
-  const ticks = toFixed ? map(range, (x: number) => Number.parseFloat(x.toFixed(toFixed))) : range;
+  const ticks = toFixed ? map(range, (x: number) => parseFloat(x.toFixed(toFixed))) : range;
 
   return {
     min: Math.min(dmin, head(ticks)),

--- a/src/util/pretty.ts
+++ b/src/util/pretty.ts
@@ -17,12 +17,12 @@ export default function pretty(min: number, max: number, n: number = 5) {
   // 当d非常小的时候触发，但似乎没什么用
   // const min_n = Math.floor(n / 3);
   // const shrink_sml = Math.pow(2, 5);
-  // if (Math.log10(d) < -2) {
+  // if ((Math.log(d)/Math.log(10)) < -2) {
   //   c = (_.max([ Math.abs(max), Math.abs(min) ]) * shrink_sml) / min_n;
   // }
 
-  const base = Math.pow(10, Math.floor(Math.log10(c)));
-  const toFixed = base < 1 ? Math.ceil(Math.abs(Math.log10(base))) : 0;
+  const base = Math.pow(10, Math.floor(Math.log(c)/Math.log(10)));
+  const toFixed = base < 1 ? Math.ceil(Math.abs(Math.log(base)/Math.log(10))) : 0;
   let unit = base;
   if (2 * base - c < h * (c - unit)) {
     unit = 2 * base;
@@ -39,12 +39,12 @@ export default function pretty(min: number, max: number, n: number = 5) {
   res.max = Math.max(nu * unit, max);
   res.min = Math.min(ns * unit, min);
 
-  let x = Number.parseFloat((ns * unit).toFixed(toFixed));
+  let x = parseFloat((ns * unit).toFixed(toFixed));
   while (x < max) {
     res.ticks.push(x);
     x += unit;
     if (toFixed) {
-      x = Number.parseFloat(x.toFixed(toFixed));
+      x = parseFloat(x.toFixed(toFixed));
     }
   }
   res.ticks.push(x);


### PR DESCRIPTION
IE11 not support Math.log10,Number.isInteger,Number.parseFloat and
Number.isNaN

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
G2's official ring [**example code**](https://antv-g2.gitee.io/zh/examples/pie/donut) in Vue project can't run on IE11 with Math.log10 error.
