### PR TITLE
fix(extentded): fix oom when min, max is invalid

### DIFF
--- a/src/util/extended.ts
+++ b/src/util/extended.ts
@@ -78,6 +78,15 @@ export default function extended(
   Q: number[] = DEFAULT_Q,
   w: [number, number, number, number] = [0.25, 0.2, 0.5, 0.05]
 ): { min: number; max: number; ticks: number[] } {
+  // 异常数据情况下，直接返回，防止 oom
+  if (typeof dmin !== 'number' || typeof dmax !== 'number') {
+    return {
+      min: 0,
+      max: 0,
+      ticks: [],
+    };
+  }
+
   if (dmin === dmax || m === 1) {
     return {
       min: dmin,

--- a/tests/bugs/issue-1-spec.js
+++ b/tests/bugs/issue-1-spec.js
@@ -1,9 +1,0 @@
-const expect = require('chai').expect;
-const scale = require('../../src/index');
-
-describe('#1', () => {
-  it('description', () => {
-    expect('scale').to.be.a('string');
-    expect(scale).to.be.an('object');
-  });
-});

--- a/tests/bugs/issue-1-spec.ts
+++ b/tests/bugs/issue-1-spec.ts
@@ -1,0 +1,7 @@
+import * as scale from '../../src/';
+
+describe('#1', () => {
+  it('description', () => {
+    expect(typeof scale).toBe('object');
+  });
+});

--- a/tests/bugs/issue-62-spec.ts
+++ b/tests/bugs/issue-62-spec.ts
@@ -1,0 +1,13 @@
+import { Linear } from '../../src';
+
+describe('#62', () => {
+  it('scale ooo', () => {
+    const scale = new Linear({
+      min: 0,
+      max: {},
+    });
+
+    // 不会出现 oom
+    expect(scale.getTicks()).toEqual([]);
+  });
+});


### PR DESCRIPTION
 - [x] fix oom + 单测
 - [x] bugs 目录的单测还是旧的格式

fixed #62 