### PR TITLE
fix: 修复 tickCount 0 导致的 oom

### DIFF
--- a/src/util/extended.ts
+++ b/src/util/extended.ts
@@ -79,7 +79,7 @@ export default function extended(
   w: [number, number, number, number] = [0.25, 0.2, 0.5, 0.05]
 ): { min: number; max: number; ticks: number[] } {
   // 异常数据情况下，直接返回，防止 oom
-  if (typeof dmin !== 'number' || typeof dmax !== 'number') {
+  if (typeof dmin !== 'number' || typeof dmax !== 'number' || !m) {
     return {
       min: 0,
       max: 0,

--- a/tests/unit/tick-method/cat-spec.ts
+++ b/tests/unit/tick-method/cat-spec.ts
@@ -2,7 +2,7 @@ import { getTickMethod } from '../../../src/tick-method/index';
 
 function getArr(count) {
   const arr = [];
-  for(let i = 0; i < count; i++) {
+  for (let i = 0; i < count; i++) {
     arr.push(i.toString());
   }
   return arr;
@@ -17,7 +17,7 @@ describe('test cat ticks', () => {
     const arr = getArr(10);
     const ticks = cat({
       values: arr,
-      tickInterval: 2
+      tickInterval: 2,
     });
     expect(ticks.length).toEqual(arr.length / 2);
   });
@@ -26,7 +26,7 @@ describe('test cat ticks', () => {
     const arr = getArr(10);
     const ticks = cat({
       values: arr,
-      tickInterval: 20
+      tickInterval: 20,
     });
     expect(ticks.length).toEqual(1);
   });
@@ -37,7 +37,7 @@ describe('test cat ticks', () => {
       values: arr,
       min: 0,
       max: 10,
-      tickCount: 3
+      tickCount: 3,
     });
     expect(ticks.length).toEqual(3);
   });
@@ -46,7 +46,7 @@ describe('test cat ticks', () => {
     const arr = getArr(10);
     const ticks = cat({
       values: arr,
-      tickCount: 3
+      tickCount: 3,
     });
     expect(ticks.length).toEqual(2);
   });
@@ -55,7 +55,7 @@ describe('test cat ticks', () => {
     const arr = getArr(10);
     const ticks = cat({
       values: arr,
-      tickCount: 20
+      tickCount: 20,
     });
     expect(ticks.length).toEqual(10);
   });
@@ -63,7 +63,7 @@ describe('test cat ticks', () => {
   it('no tickCount or tickInterval', () => {
     const arr = getArr(10);
     const ticks = cat({
-      values: arr
+      values: arr,
     });
     expect(ticks).toEqual(arr);
   });
@@ -73,9 +73,17 @@ describe('test cat ticks', () => {
     const ticks = cat({
       values: arr,
       min: 2,
-      max: 8
+      max: 8,
     });
     expect(ticks.length).toEqual(8 - 2 + 1);
   });
-  
+
+  it('tick count with 0', () => {
+    const arr = getArr(10);
+    const ticks = cat({
+      values: arr,
+      tickCount: 0,
+    });
+    expect(ticks.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

Tick count 0 导致 extended 跳不出 while 循环。
