### PR TITLE
refactor(type): extract TickOptions from BaseOptions

### DIFF
--- a/__tests__/unit/scales/base.spec.ts
+++ b/__tests__/unit/scales/base.spec.ts
@@ -1,6 +1,5 @@
 import { Base } from '../../../src/scales/base';
 import { BaseOptions, Domain, Range } from '../../../src/types';
-import { ticks } from '../../../src/tick-method/basic';
 
 class Scale extends Base<BaseOptions> {
   // eslint-disable-next-line class-methods-use-this
@@ -22,28 +21,20 @@ describe('Scale', () => {
   test('Scale() has expected defaults', () => {
     const s = new Scale();
     // @ts-ignore
-    const { formatter, tickMethod, ...restOptions } = s.options;
+    const { formatter, ...restOptions } = s.options;
 
     expect(restOptions).toEqual({
       domain: [0, 1],
       range: [0, 1],
-      tickCount: 5,
-      tickInterval: 10,
     });
     expect(formatter(1)).toBe('1');
-    // @ts-ignore
-    expect(tickMethod(s.options)).toEqual([]);
-    expect(tickMethod).toEqual(ticks);
   });
 
   test('Scale(options) override defaults', () => {
     const s = new Scale({
-      tickCount: 20,
       domain: [0, 10],
     });
 
-    // @ts-ignore
-    expect(s.options.tickCount).toBe(20);
     // @ts-ignore
     expect(s.options.domain).toEqual([0, 10]);
   });
@@ -65,28 +56,11 @@ describe('Scale', () => {
     const s = new Scale();
 
     s.update({
-      tickCount: 10,
       domain: [0, 10],
     });
 
     const options = s.getOptions();
-
-    expect(options.tickCount).toBe(10);
     expect(options.domain).toEqual([0, 10]);
-  });
-
-  test('getTicks() call options.tickMethod and return its return value', () => {
-    const s = new Scale();
-    const mockFn = jest.fn();
-    s.update({
-      tickMethod: () => {
-        mockFn();
-        return [1, 2, 3, 4, 5];
-      },
-    });
-
-    expect(s.getTicks()).toEqual([1, 2, 3, 4, 5]);
-    expect(mockFn).toBeCalled();
   });
 
   test('clone() return a scale belong to same class', () => {
@@ -106,13 +80,13 @@ describe('Scale', () => {
     const s1 = s.clone();
 
     s.update({
-      tickCount: 20,
+      domain: [0, 10],
     });
-    expect(s1.getOptions().tickCount).toBe(5);
+    expect(s1.getOptions().domain).toEqual([0, 1]);
 
     s1.update({
-      tickCount: 30,
+      domain: [0, 100],
     });
-    expect(s.getOptions().tickCount).toBe(20);
+    expect(s.getOptions().domain).toEqual([0, 10]);
   });
 });

--- a/__tests__/unit/scales/constant.spec.ts
+++ b/__tests__/unit/scales/constant.spec.ts
@@ -71,6 +71,20 @@ describe('Constant', () => {
     expect(x.invert(undefined)).toEqual([]);
   });
 
+  test('getTicks() call options.tickMethod and return its return value', () => {
+    const s = new Constant();
+    const mockFn = jest.fn();
+    s.update({
+      tickMethod: () => {
+        mockFn();
+        return [1, 2, 3, 4, 5];
+      },
+    });
+
+    expect(s.getTicks()).toEqual([1, 2, 3, 4, 5]);
+    expect(mockFn).toBeCalled();
+  });
+
   test('clone() return a scale belong to same class', () => {
     const s = new Constant();
     const s1 = s.clone();

--- a/__tests__/unit/scales/identity.spec.ts
+++ b/__tests__/unit/scales/identity.spec.ts
@@ -56,6 +56,20 @@ describe('Identity', () => {
     expect(x.invert(2.5)).toBe(2.5);
   });
 
+  test('getTicks() call options.tickMethod and return its return value', () => {
+    const s = new Identity();
+    const mockFn = jest.fn();
+    s.update({
+      tickMethod: () => {
+        mockFn();
+        return [1, 2, 3, 4, 5];
+      },
+    });
+
+    expect(s.getTicks()).toEqual([1, 2, 3, 4, 5]);
+    expect(mockFn).toBeCalled();
+  });
+
   test('clone() return a scale belong to same class', () => {
     const s = new Identity();
     const s1 = s.clone();

--- a/__tests__/unit/tick-methods/baisc.spec.ts
+++ b/__tests__/unit/tick-methods/baisc.spec.ts
@@ -1,0 +1,8 @@
+import { ticks } from '../../../src/tick-method/basic';
+
+describe('Basic tick method', () => {
+  // 该方法还没有实现，现在简单测试一下提高覆盖率，不然 CI 会出问题
+  test('tics[] return []', () => {
+    expect(ticks()).toEqual([]);
+  });
+});

--- a/src/scales/base.ts
+++ b/src/scales/base.ts
@@ -1,5 +1,4 @@
 import { assign } from '@antv/util';
-import { ticks } from '../tick-method/basic';
 import { BaseOptions, Domain, Range, Unknown } from '../types';
 
 export abstract class Base<O extends BaseOptions> {
@@ -28,10 +27,7 @@ export abstract class Base<O extends BaseOptions> {
   protected defaultOptions: O = {
     domain: [0, 1],
     range: [0, 1],
-    tickCount: 5,
-    tickInterval: 10,
     formatter: (x: Range<O>) => `${x}`,
-    tickMethod: ticks,
   } as O;
 
   /**
@@ -58,13 +54,5 @@ export abstract class Base<O extends BaseOptions> {
    */
   public update(updateOptions: Partial<O>) {
     assign(this.options, updateOptions);
-  }
-
-  /**
-   * 根据比例尺的配置去生成 ticks，该 ticks 主要用于生成坐标轴
-   * @returns 返回一个 ticks 的数组
-   */
-  public getTicks(): Range<O>[] {
-    return this.options.tickMethod(this.options);
   }
 }

--- a/src/scales/constant.ts
+++ b/src/scales/constant.ts
@@ -1,5 +1,6 @@
 import { ConstantOptions, Domain, Range } from '../types';
 import { Base } from './base';
+import { ticks } from '../tick-method/basic';
 
 export class Constant extends Base<ConstantOptions> {
   /**
@@ -7,7 +8,12 @@ export class Constant extends Base<ConstantOptions> {
    * @param options 需要自定义配置的选项
    */
   constructor(options?: Partial<ConstantOptions>) {
-    super(options, { range: [0] });
+    super(options, {
+      range: [0],
+      tickCount: 5,
+      tickInterval: 10,
+      tickMethod: ticks,
+    });
   }
 
   /**
@@ -37,5 +43,13 @@ export class Constant extends Base<ConstantOptions> {
    */
   public clone() {
     return new Constant(this.options);
+  }
+
+  /**
+   * 根据比例尺的配置去生成 ticks，该 ticks 主要用于生成坐标轴
+   * @returns 返回一个 ticks 的数组
+   */
+  public getTicks(): Range<ConstantOptions>[] {
+    return this.options.tickMethod(this.options);
   }
 }

--- a/src/scales/identity.ts
+++ b/src/scales/identity.ts
@@ -1,8 +1,21 @@
 import { isNumber } from '@antv/util';
 import { Base } from './base';
 import { IdentityOptions, Domain, Range } from '../types';
+import { ticks } from '../tick-method/basic';
 
 export class Identity extends Base<IdentityOptions> {
+  /**
+   * 覆盖默认配置
+   * @param options 需要自定义配置的选项
+   */
+  constructor(options?: Partial<IdentityOptions>) {
+    super(options, {
+      tickCount: 5,
+      tickInterval: 10,
+      tickMethod: ticks,
+    });
+  }
+
   /**
    * 输入和输出满足：y = x
    * @param x 输入值
@@ -27,5 +40,13 @@ export class Identity extends Base<IdentityOptions> {
    */
   public clone() {
     return new Identity(this.options);
+  }
+
+  /**
+   * 根据比例尺的配置去生成 ticks，该 ticks 主要用于生成坐标轴
+   * @returns 返回一个 ticks 的数组
+   */
+  public getTicks(): Range<IdentityOptions>[] {
+    return this.options.tickMethod(this.options);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type TickMethod<T> = (options?: T) => any[];
  * R：值域元素的类型
  * T：tickMethod 配置项的类型
  */
-export type BaseOptions<D = any, R = any, T = any> = {
+export type BaseOptions<D = any, R = any> = {
   /** 当需要映射的值不合法的时候，返回的值 */
   unknown?: any;
   /** 值域，默认为 [0, 1] */
@@ -15,6 +15,12 @@ export type BaseOptions<D = any, R = any, T = any> = {
   domain?: D[];
   /** tick 格式化函数，会影响数据在坐标轴 axis、legend、tooltip 上的显示 */
   formatter?: (x: R) => string;
+};
+
+/**
+ * 支持 getTicks 的比例尺的选项
+ */
+export type TickOptions<T = any> = {
   /** tick 个数，默认值为 5 */
   tickCount?: number;
   /** tick 间隔的最大值，默认值为 10 */
@@ -32,6 +38,6 @@ export type Range<O extends BaseOptions> = O['range'][number];
 /** 获得比例尺选项中 unknown 的类型 */
 export type Unknown<O extends BaseOptions> = O['unknown'];
 
-export type IdentityOptions = BaseOptions<number, number>;
+export type IdentityOptions = BaseOptions<number, number> & TickOptions;
 
-export type ConstantOptions = BaseOptions<number | string, number | string>;
+export type ConstantOptions = BaseOptions<number | string, number | string> & TickOptions;


### PR DESCRIPTION
#### 拆分了一下 BaseOptions

之前忽略了有的比例尺没有 getTicks 方法，比如 category，band 这些。所以 BaseOptions 里面也包含了 tickCount 这些属性，并且基类有 getTicks 方法。因为社区小伙伴要先从 category 入手，为了防止迷糊，做了以下简单的重构。

- 将 BaseOptions 里面的和 getTicks 相关的选项抽离出来为 TickOptions，有 getTicks 的比例尺的类型 & 上这个类型。
- 移除了 Base 里面的 getTicks 方法，需要 getTicks 的子类自己实现该方法即可。