### PR TITLE
refactor(base): add getDefaultOptions to override defualt options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'import/extensions': 'off',
     'import/prefer-default-export': 'off',
     'object-curly-newline': 'off',
+    'class-methods-use-this': 'off',
   },
   settings: {
     'import/parsers': {

--- a/__tests__/unit/scales/base.spec.ts
+++ b/__tests__/unit/scales/base.spec.ts
@@ -2,12 +2,10 @@ import { Base } from '../../../src/scales/base';
 import { BaseOptions, Domain, Range } from '../../../src/types';
 
 class Scale extends Base<BaseOptions> {
-  // eslint-disable-next-line class-methods-use-this
   public map(x: Domain<BaseOptions>) {
     return x;
   }
 
-  // eslint-disable-next-line class-methods-use-this
   public invert(x: Range<BaseOptions>) {
     return x;
   }
@@ -17,7 +15,7 @@ class Scale extends Base<BaseOptions> {
   }
 }
 
-describe('Scale', () => {
+describe('Base', () => {
   test('Scale() has expected defaults', () => {
     const s = new Scale();
     // @ts-ignore
@@ -37,13 +35,6 @@ describe('Scale', () => {
 
     // @ts-ignore
     expect(s.options.domain).toEqual([0, 10]);
-  });
-
-  test('Scale({}, defaults) set defaults', () => {
-    const s = new Scale({}, { domain: [0, 20] });
-
-    // @ts-ignore
-    expect(s.options.domain).toEqual([0, 20]);
   });
 
   test('getOptions() return current Options', () => {

--- a/src/scales/base.ts
+++ b/src/scales/base.ts
@@ -35,15 +35,15 @@ export abstract class Base<O extends BaseOptions> {
    * @param options 需要自定义配置的选项
    */
   constructor(options?: Partial<O>) {
-    assign(this.defaultOptions, this.getDefaultOptions());
-    assign(this.options, this.defaultOptions, options);
+    this.defaultOptions = assign(this.defaultOptions, this.getDefaultOptions()) as O;
+    this.options = assign(this.options, this.defaultOptions, options);
   }
 
   /**
    * 子类需要覆盖的默认配置
    */
   protected getDefaultOptions(): Partial<O> {
-    return {} as O;
+    return {};
   }
 
   /**

--- a/src/scales/base.ts
+++ b/src/scales/base.ts
@@ -33,11 +33,17 @@ export abstract class Base<O extends BaseOptions> {
   /**
    * 构造函数
    * @param options 需要自定义配置的选项
-   * @param overrideDefaultOptions 覆盖默认选项，子类可以通过这个参数对基本的默认选项进行覆盖
    */
-  constructor(options?: Partial<O>, overrideDefaultOptions?: Partial<O>) {
-    assign(this.defaultOptions, overrideDefaultOptions);
+  constructor(options?: Partial<O>) {
+    assign(this.defaultOptions, this.getDefaultOptions());
     assign(this.options, this.defaultOptions, options);
+  }
+
+  /**
+   * 子类需要覆盖的默认配置
+   */
+  protected getDefaultOptions(): Partial<O> {
+    return {} as O;
   }
 
   /**

--- a/src/scales/base.ts
+++ b/src/scales/base.ts
@@ -21,28 +21,29 @@ export abstract class Base<O extends BaseOptions> {
   abstract clone(): Base<O>;
 
   /** 比例尺的选项，用于配置数据映射的规则和 ticks 的生成方式 */
-  protected options: O = {} as O;
+  protected options: O;
 
   /** 比例尺的默认选项，子类可以自定义默认选项 */
-  protected defaultOptions: O = {
-    domain: [0, 1],
-    range: [0, 1],
-    formatter: (x: Range<O>) => `${x}`,
-  } as O;
+  protected readonly defaultOptions: O;
 
   /**
-   * 构造函数
+   * 构造函数，根据自定义的选项和默认选项生成当前选项
    * @param options 需要自定义配置的选项
    */
   constructor(options?: Partial<O>) {
-    this.defaultOptions = assign({} as O, this.defaultOptions, this.getDefaultOptions());
+    const BASE_DEFAULT_OPTIONS = {
+      domain: [0, 1],
+      range: [0, 1],
+      formatter: (x: Range<O>) => `${x}`,
+    } as O;
+    this.defaultOptions = assign({} as O, BASE_DEFAULT_OPTIONS, this.getOverrideDefaultOptions());
     this.options = assign({} as O, this.defaultOptions, options);
   }
 
   /**
    * 子类需要覆盖的默认配置
    */
-  protected getDefaultOptions(): Partial<O> {
+  protected getOverrideDefaultOptions(): Partial<O> {
     return {};
   }
 

--- a/src/scales/base.ts
+++ b/src/scales/base.ts
@@ -23,7 +23,7 @@ export abstract class Base<O extends BaseOptions> {
   /** 比例尺的选项，用于配置数据映射的规则和 ticks 的生成方式 */
   protected options: O = {} as O;
 
-  /** 比例尺扽默认选项，子类可以自定义默认选项 */
+  /** 比例尺的默认选项，子类可以自定义默认选项 */
   protected defaultOptions: O = {
     domain: [0, 1],
     range: [0, 1],
@@ -35,8 +35,8 @@ export abstract class Base<O extends BaseOptions> {
    * @param options 需要自定义配置的选项
    */
   constructor(options?: Partial<O>) {
-    this.defaultOptions = assign(this.defaultOptions, this.getDefaultOptions()) as O;
-    this.options = assign(this.options, this.defaultOptions, options);
+    this.defaultOptions = assign({} as O, this.defaultOptions, this.getDefaultOptions());
+    this.options = assign({} as O, this.defaultOptions, options);
   }
 
   /**
@@ -48,7 +48,7 @@ export abstract class Base<O extends BaseOptions> {
 
   /**
    * 返回当前的所有选项
-   * @returns
+   * @returns 当前的所有选项
    */
   public getOptions() {
     return this.options;

--- a/src/scales/category.ts
+++ b/src/scales/category.ts
@@ -72,11 +72,11 @@ export class Category extends Base<CategoryOptions> {
   private rangeIndexMap: Map<any, number> = new Map();
 
   // 覆盖默认配置
-  constructor(options?: Partial<CategoryOptions>) {
-    super(options, {
+  protected getDefaultOptions() {
+    return {
       domain: [],
       range: [],
-    });
+    };
   }
 
   private initDomainIndexMap() {

--- a/src/scales/category.ts
+++ b/src/scales/category.ts
@@ -72,7 +72,7 @@ export class Category extends Base<CategoryOptions> {
   private rangeIndexMap: Map<any, number> = new Map();
 
   // 覆盖默认配置
-  protected getDefaultOptions() {
+  protected getOverrideDefaultOptions() {
     return {
       domain: [],
       range: [],

--- a/src/scales/constant.ts
+++ b/src/scales/constant.ts
@@ -7,7 +7,7 @@ export class Constant extends Base<ConstantOptions> {
    * 返回需要覆盖的默认选项
    * @returns 需要覆盖的默认选项
    */
-  protected getDefaultOptions() {
+  protected getOverrideDefaultOptions() {
     return {
       range: [0],
       tickCount: 5,

--- a/src/scales/constant.ts
+++ b/src/scales/constant.ts
@@ -4,16 +4,16 @@ import { ticks } from '../tick-method/basic';
 
 export class Constant extends Base<ConstantOptions> {
   /**
-   * 覆盖默认配置
-   * @param options 需要自定义配置的选项
+   * 返回需要覆盖的默认选项
+   * @returns 需要覆盖的默认选项
    */
-  constructor(options?: Partial<ConstantOptions>) {
-    super(options, {
+  protected getDefaultOptions() {
+    return {
       range: [0],
       tickCount: 5,
       tickInterval: 10,
       tickMethod: ticks,
-    });
+    };
   }
 
   /**

--- a/src/scales/identity.ts
+++ b/src/scales/identity.ts
@@ -8,7 +8,7 @@ export class Identity extends Base<IdentityOptions> {
    * 返回需要覆盖的默认选项
    * @returns 需要覆盖的默认选项
    */
-  protected getDefaultOptions() {
+  protected getOverrideDefaultOptions() {
     return {
       tickCount: 5,
       tickInterval: 10,

--- a/src/scales/identity.ts
+++ b/src/scales/identity.ts
@@ -5,15 +5,15 @@ import { ticks } from '../tick-method/basic';
 
 export class Identity extends Base<IdentityOptions> {
   /**
-   * 覆盖默认配置
-   * @param options 需要自定义配置的选项
+   * 返回需要覆盖的默认选项
+   * @returns 需要覆盖的默认选项
    */
-  constructor(options?: Partial<IdentityOptions>) {
-    super(options, {
+  protected getDefaultOptions() {
+    return {
       tickCount: 5,
       tickInterval: 10,
       tickMethod: ticks,
-    });
+    };
   }
 
   /**


### PR DESCRIPTION
### 改变了覆盖默认配置的方式

发现现在覆盖默认配置的方式不能多层继承，所以修改了一下 Base 类覆盖默认配置的方式。修改之后的覆盖方式如下：

```ts
type CategoryOptions = {};

class Category<O extends CategoryOptions> extends Base<O> {
  protected getOverrideDefaultOptions() {
    return {/*...*/}  as O;
  }

  public clone() {
    return new Category<O>(this.options);
  }
}

type BandOptions = {};

class Band extends Category<BandOptions> {
  protected getOverrideDefaultOptions() {
    return {/*...*/} ;
  }
}
```
