### PR TITLE
Docs/unify

### DIFF
--- a/docs/band.md
+++ b/docs/band.md
@@ -32,7 +32,7 @@ x.getBandWidth();  // 25
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a tick value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
 | round | If round option is truthy, the start and stop of each band will be integers. | `boolean` | `false` |
 | paddingInner | Set the scale's paddingInner, the value should in the range [0, 1]. For more info, please see the [example](#example) below | `number` | `0` |
 | paddingOuter | Set the scale's paddingOuter, the value should in the range [0, 1]. For more info, please see the [example](#example) below | `number` | `0` |

--- a/docs/band.md
+++ b/docs/band.md
@@ -32,7 +32,7 @@ x.getBandWidth();  // 25
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
+| formatter | Sets the format function to display the output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 | round | If round option is truthy, the start and stop of each band will be integers. | `boolean` | `false` |
 | paddingInner | Set the scale's paddingInner, the value should in the range [0, 1]. For more info, please see the [example](#example) below | `number` | `0` |
 | paddingOuter | Set the scale's paddingOuter, the value should in the range [0, 1]. For more info, please see the [example](#example) below | `number` | `0` |

--- a/docs/band.md
+++ b/docs/band.md
@@ -32,7 +32,7 @@ x.getBandWidth();  // 25
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 | round | If round option is truthy, the start and stop of each band will be integers. | `boolean` | `false` |
 | paddingInner | Set the scale's paddingInner, the value should in the range [0, 1]. For more info, please see the [example](#example) below | `number` | `0` |
 | paddingOuter | Set the scale's paddingOuter, the value should in the range [0, 1]. For more info, please see the [example](#example) below | `number` | `0` |

--- a/docs/category.md
+++ b/docs/category.md
@@ -28,7 +28,7 @@ x.map('C'); // c
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` or `string[]` | `[]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a tick value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
 
 ## Methods
 

--- a/docs/category.md
+++ b/docs/category.md
@@ -28,15 +28,15 @@ x.map('C'); // c
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` or `string[]` | `[]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
+| formatter | Sets the format function to display the output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 
 ## Methods
 
-<a name="category_map" href="#category_map">#</a> **map**<i>(x: number[] or string[]): number[] or string[]</i>
+<a name="category_map" href="#category_map">#</a> **map**<i>(x: (number | string)[]): (number | string)[]</i>
 
 Returns the input value itself if it is not `undefined` (or `NaN`), otherwise `options.unknown`.
 
-<a name="category_invert" href="#category_invert">#</a> **invert**<i>(x: x: number[] or string[]): x: number[] or string[]</i>
+<a name="category_invert" href="#category_invert">#</a> **invert**<i>(x: (number | string) []): (number| string)[]</i>
 
 Returns the output value itself.
 

--- a/docs/category.md
+++ b/docs/category.md
@@ -28,7 +28,7 @@ x.map('C'); // c
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` or `string[]` | `[]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 
 ## Methods
 

--- a/docs/constant.md
+++ b/docs/constant.md
@@ -30,7 +30,7 @@ x.invert('2'); // [0, 10]
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[0, 1]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a tick value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
 
 ## Methods
 

--- a/docs/constant.md
+++ b/docs/constant.md
@@ -30,7 +30,7 @@ x.invert('2'); // [0, 10]
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[0, 1]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
+| formatter | Sets the format function to display the output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 
 ## Methods
 
@@ -42,14 +42,14 @@ Returns the first element of range if it is not `undefined` (or `NaN`), otherwis
 
 Returns the domain.
 
-<a name="constant_update" href="#constant_update">#</a> **update**<i>(options: constantOptions): void</i>
+<a name="constant_update" href="#constant_update">#</a> **update**<i>(options: ConstantOptions): void</i>
 
 Update the scale's options and rescale.
 
-<a name="constant_getOptions" href="#constant_getOptions">#</a> **getOptions**<i>(): constantOptions</i>
+<a name="constant_getOptions" href="#constant_getOptions">#</a> **getOptions**<i>(): ConstantOptions</i>
 
 Returns the scale's current options.
 
-<a name="constant_clone" href="#constant_clone">#</a> **clone**<i>(): constant</i>
+<a name="constant_clone" href="#constant_clone">#</a> **clone**<i>(): Constant</i>
 
 Returns a new constant scale with the independent and same options as the original one.

--- a/docs/constant.md
+++ b/docs/constant.md
@@ -30,7 +30,7 @@ x.invert('2'); // [0, 10]
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[0, 1]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 
 ## Methods
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -27,7 +27,7 @@ x.getTicks(); // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` | `[0, 1]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a tick value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
 | tickCount | Sets approximately count representative values from the scale’s domain. | `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(options?: IdentityOptions) => number[]` | r-pretty|
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -27,7 +27,7 @@ x.getTicks(); // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` | `[0, 1]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
+| formatter | Sets the format function to display the output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 | tickCount | Sets approximately count representative values from the scale’s domain. | `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(options?: IdentityOptions) => number[]` | r-pretty|
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -27,7 +27,7 @@ x.getTicks(); // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` | `[0, 1]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 | tickCount | Sets approximately count representative values from the scale’s domain. | `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(options?: IdentityOptions) => number[]` | r-pretty|
 

--- a/docs/point.md
+++ b/docs/point.md
@@ -28,7 +28,7 @@ scale.getBandWidth(); // always 0
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a tick value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
 | round | If round option is truthy, the start and stop of each point will be integers. | `boolean` | `false` |
 | padding | Set the scale's padding. In fact, this is the `outerPadding` of the band option. For more info about this, please see [example](#example). | `number` | `0` |
 | align | The `align` option specifies how outer padding is distributed in the range, the value should in the range [0, 1]. For example, value of 0.5 means that points should be centered within the range, value of 0 or 1 may be used to shift the points to one side. | `number` | `0.5` |

--- a/docs/point.md
+++ b/docs/point.md
@@ -28,7 +28,7 @@ scale.getBandWidth(); // always 0
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}```|
+| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 | round | If round option is truthy, the start and stop of each point will be integers. | `boolean` | `false` |
 | padding | Set the scale's padding. In fact, this is the `outerPadding` of the band option. For more info about this, please see [example](#example). | `number` | `0` |
 | align | The `align` option specifies how outer padding is distributed in the range, the value should in the range [0, 1]. For example, value of 0.5 means that points should be centered within the range, value of 0 or 1 may be used to shift the points to one side. | `number` | `0.5` |

--- a/docs/point.md
+++ b/docs/point.md
@@ -28,7 +28,7 @@ scale.getBandWidth(); // always 0
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` or `string[]` | `[]` |
 | range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
-| formatter | Sets the format function to display a output value. | `(x: any) => string` | ```(x) => `${x}` ```|
+| formatter | Sets the format function to display the output value. | `(x: any) => string` | ```(x) => `${x}` ```|
 | round | If round option is truthy, the start and stop of each point will be integers. | `boolean` | `false` |
 | padding | Set the scale's padding. In fact, this is the `outerPadding` of the band option. For more info about this, please see [example](#example). | `number` | `0` |
 | align | The `align` option specifies how outer padding is distributed in the range, the value should in the range [0, 1]. For example, value of 0.5 means that points should be centered within the range, value of 0 or 1 may be used to shift the points to one side. | `number` | `0.5` |
@@ -64,7 +64,7 @@ Update the scale's options and rescale.
 
 Returns the scale's current options.
 
-<a name="point_clone" href="#point_clone">#</a> **clone**<i>(): point</i>
+<a name="point_clone" href="#point_clone">#</a> **clone**<i>(): Point</i>
 
 Returns a new point scale with the independent and same options as the original one.
 
@@ -76,7 +76,3 @@ Returns point scale's step, for more info about this, please see [example](#exam
 
 Returns point scale's `bandWidth`, In fact, the value is always 0. For more info about this, please
 see [example](#example).
-
-
-
-


### PR DESCRIPTION
### 修复和统一了文档

- 大小写问题
- 函数的签名写法的统一
- formatter 的解释