### PR TITLE
fix: fix wrong usage for toBeCloseTo() API

### DIFF
--- a/__tests__/unit/scales/band.spec.ts
+++ b/__tests__/unit/scales/band.spec.ts
@@ -1,5 +1,4 @@
-import { Band } from '../../../src/scales/band';
-import { BandOptions } from '../../../src/types';
+import { Band, BandOptions } from '../../../src';
 
 describe('band scale', () => {
   test('default options and methods', () => {
@@ -62,7 +61,7 @@ describe('band scale', () => {
     bandScale.update({
       paddingInner: 0.1,
     });
-    expect(bandScale.getStep()).toBeCloseTo(172.41, -2);
+    expect(bandScale.getStep()).toBeCloseTo(172.414, 3);
   });
 
   test('test padding-outer option', () => {
@@ -72,7 +71,7 @@ describe('band scale', () => {
       paddingOuter: 0.2,
     });
 
-    expect(bandScale.getStep()).toBeCloseTo(147.05, -2);
+    expect(bandScale.getStep()).toBeCloseTo(147.059, 3);
   });
 
   test('test round option', () => {
@@ -83,9 +82,9 @@ describe('band scale', () => {
       paddingOuter: 0.2,
     });
 
-    expect(bandScale.map('A')).toBeCloseTo(29.41, -2);
-    expect(bandScale.map('B')).toBeCloseTo(176.47, -2);
-    expect(bandScale.map('C')).toBeCloseTo(323.52, -2);
+    expect(bandScale.map('A')).toBeCloseTo(29.41, 2);
+    expect(bandScale.map('B')).toBeCloseTo(176.47, 2);
+    expect(bandScale.map('C')).toBeCloseTo(323.53, 2);
 
     bandScale.update({
       round: true,

--- a/__tests__/unit/scales/pow.spec.ts
+++ b/__tests__/unit/scales/pow.spec.ts
@@ -26,7 +26,7 @@ describe('pow scales', () => {
 
     expect(scale.map(25)).toStrictEqual(50);
     expect(scale.map(-25)).toStrictEqual(-50);
-    expect(scale.map(50)).toBeCloseTo(70.71, -2);
+    expect(scale.map(50)).toBeCloseTo(70.71, 2);
   });
 
   test('test when exponent is 1, we use identity', () => {
@@ -39,7 +39,7 @@ describe('pow scales', () => {
     expect(scale.map(25)).toStrictEqual(25);
     expect(scale.map(-25)).toStrictEqual(-25);
     expect(scale.invert(-25)).toStrictEqual(-25);
-    expect(scale.map(50)).toBeCloseTo(50);
+    expect(scale.map(50)).toStrictEqual(50);
   });
 
   test('map fn', () => {
@@ -51,7 +51,7 @@ describe('pow scales', () => {
 
     expect(scale.map(0)).toStrictEqual(0);
     expect(scale.map(25)).toStrictEqual(6.25);
-    expect(scale.map(50)).toBeCloseTo(25);
+    expect(scale.map(50)).toStrictEqual(25);
     expect(scale.map(100)).toStrictEqual(100);
     expect(scale.map(-25)).toStrictEqual(-6.25);
   });
@@ -111,8 +111,8 @@ describe('pow scales', () => {
     });
 
     expect(scale.map(0)).toStrictEqual(0);
-    expect(scale.map(60)).toBeCloseTo(70.71, -2);
-    expect(scale.map(-60)).toBeCloseTo(-70.71, -2);
+    expect(scale.map(60)).toStrictEqual(25);
+    expect(scale.map(-60)).toStrictEqual(-25);
   });
 
   test('test nice option', () => {


### PR DESCRIPTION
- [x] 修正 tobeCloseTo() 的错误用法。
- [x] 修复 pow 的一个 test case 的结果错误，pow 本身的算法没有错误，原因在于 tobeCloseTo 的错误用法导致改了 options 之后断言仍然通过。