### PR TITLE
refactor: unify scale flow and simplify code

### DIFF
--- a/__tests__/unit/scales/base.spec.ts
+++ b/__tests__/unit/scales/base.spec.ts
@@ -2,6 +2,13 @@ import { Base } from '../../../src/scales/base';
 import { BaseOptions, Domain, Range } from '../../../src/types';
 
 class Scale extends Base<BaseOptions> {
+  protected getDefaultOptions() {
+    return {
+      domain: [0, 1],
+      range: [0, 1],
+    };
+  }
+
   public map(x: Domain<BaseOptions>) {
     return x;
   }

--- a/src/scales/band.ts
+++ b/src/scales/band.ts
@@ -113,16 +113,16 @@ function getBandState(opt: BandStateOptions) {
  */
 export class Band<O extends BandOptions> extends Ordinal<O> {
   // 步长，见上图
-  private step: number = 0;
+  private step: number;
 
   // band 宽度
-  private bandWidth: number = 0;
+  private bandWidth: number;
 
   // 转换过的 range
   private adjustedRange: O['range'];
 
   // 覆盖默认配置
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions() {
     return {
       domain: [],
       range: [0, 1],
@@ -138,16 +138,10 @@ export class Band<O extends BandOptions> extends Ordinal<O> {
   // 显示指定 options 的类型为 OrdinalOptions，从而推断出 O 的类型
   constructor(options?: BandOptions) {
     super(options as O);
-    this.rescale();
   }
 
   public clone() {
     return new Band<O>(this.options);
-  }
-
-  public update(updateOptions: Partial<O>) {
-    super.update(updateOptions);
-    this.rescale();
   }
 
   public getStep() {
@@ -173,6 +167,7 @@ export class Band<O extends BandOptions> extends Ordinal<O> {
   }
 
   protected rescale() {
+    super.rescale();
     // 当用户配置了opt.padding 且非 0 时，我们覆盖已经设置的 paddingInner paddingOuter
     // 我们约定 padding 的优先级较 paddingInner 和 paddingOuter 高
     const { align, domain, range, round } = this.options;

--- a/src/scales/base.ts
+++ b/src/scales/base.ts
@@ -20,45 +20,47 @@ export abstract class Base<O extends BaseOptions> {
    */
   abstract clone(): Base<O>;
 
-  /** 比例尺的选项，用于配置数据映射的规则和 ticks 的生成方式 */
-  protected options: O;
+  /**
+   * 子类需要覆盖的默认配置
+   */
+  protected abstract getDefaultOptions(): Partial<O>;
 
-  /** 比例尺的默认选项，子类可以自定义默认选项 */
-  protected readonly defaultOptions: O;
+  /**
+   * 比例尺的选项，用于配置数据映射的规则和 ticks 的生成方式
+   */
+  protected options: O;
 
   /**
    * 构造函数，根据自定义的选项和默认选项生成当前选项
    * @param options 需要自定义配置的选项
    */
   constructor(options?: O) {
-    const BASE_DEFAULT_OPTIONS = {
-      domain: [0, 1],
-      range: [0, 1],
-    } as O;
-    this.defaultOptions = deepMix({}, BASE_DEFAULT_OPTIONS, this.getOverrideDefaultOptions());
-    this.options = deepMix({}, this.defaultOptions, options);
-  }
-
-  /**
-   * 子类需要覆盖的默认配置
-   */
-  protected getOverrideDefaultOptions(): Partial<O> {
-    return {};
+    this.options = deepMix({}, this.getDefaultOptions());
+    this.update(options);
   }
 
   /**
    * 返回当前的所有选项
    * @returns 当前的所有选项
    */
-  public getOptions() {
+  public getOptions(): O {
     return this.options;
   }
 
   /**
-   * 更新选项
+   * 更新选项和比例尺的内部状态
    * @param updateOptions 需要更新的选项
    */
-  public update(updateOptions: Partial<O>) {
+  public update(updateOptions: Partial<O> = {}): void {
     this.options = deepMix({}, this.options, updateOptions);
+    this.rescale(updateOptions);
   }
+
+  /**
+   * 根据需要更新 options 和更新后的 options 更新 scale 的内部状态，
+   * 在函数内部可以用 this.options 获得更新后的 options
+   * @param options 需要更新的 options
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected rescale(options?: Partial<O>): void {}
 }

--- a/src/scales/constant.ts
+++ b/src/scales/constant.ts
@@ -6,9 +6,11 @@ export class Constant extends Base<ConstantOptions> {
    * 返回需要覆盖的默认选项
    * @returns 需要覆盖的默认选项
    */
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions(): ConstantOptions {
     return {
       range: [0],
+      domain: [0, 1],
+      unknown: undefined,
     };
   }
 

--- a/src/scales/identity.ts
+++ b/src/scales/identity.ts
@@ -8,9 +8,12 @@ export class Identity extends Base<IdentityOptions> {
    * 返回需要覆盖的默认选项
    * @returns 需要覆盖的默认选项
    */
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions(): IdentityOptions {
     return {
+      domain: [0, 1],
+      range: [0, 1],
       tickCount: 5,
+      unknown: undefined,
       tickMethod: wilkinsonExtended,
     };
   }

--- a/src/scales/linear.ts
+++ b/src/scales/linear.ts
@@ -10,7 +10,6 @@ import { d3Linear } from '../tick-methods/d3-linear';
  *
  * 构造可创建一个在输入和输出之间具有线性关系的比例尺
  */
-
 export class Linear extends Continuous<LinearOptions> {
   protected getDefaultOptions(): LinearOptions {
     return {

--- a/src/scales/linear.ts
+++ b/src/scales/linear.ts
@@ -2,7 +2,7 @@ import { identity } from '@antv/util';
 import { Continuous, Transform } from './continuous';
 import { LinearOptions } from '../types';
 import { Base } from './base';
-import { createInterpolate, d3LinearNice } from '../utils';
+import { createInterpolate } from '../utils';
 import { d3Linear } from '../tick-methods/d3-linear';
 
 /**
@@ -12,39 +12,25 @@ import { d3Linear } from '../tick-methods/d3-linear';
  */
 
 export class Linear extends Continuous<LinearOptions> {
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions(): LinearOptions {
     return {
+      domain: [0, 1],
+      range: [0, 1],
+      unknown: undefined,
       nice: false,
       clamp: false,
       round: false,
       interpolate: createInterpolate,
       tickMethod: d3Linear,
       tickCount: 5,
-    } as LinearOptions;
+    };
   }
 
-  protected chooseTransform(): Transform {
-    return identity;
-  }
-
-  protected chooseUntransform(): Transform {
-    return identity;
+  protected chooseTransforms(): Transform[] {
+    return [identity, identity];
   }
 
   public clone(): Base<LinearOptions> {
     return new Linear(this.options);
-  }
-
-  public getTicks() {
-    const { tickCount, domain, tickMethod } = this.options;
-    const lastIndex = domain.length - 1;
-    const dMin = domain[0];
-    const dMax = domain[lastIndex];
-    return tickMethod(dMin, dMax, tickCount);
-  }
-
-  protected nice() {
-    const { domain } = this.options;
-    this.options.domain = d3LinearNice(domain);
   }
 }

--- a/src/scales/log.ts
+++ b/src/scales/log.ts
@@ -1,6 +1,6 @@
 import { Continuous } from './continuous';
-import { LogOptions, PowOptions } from '../types';
-import { createInterpolate, d3LinearNice } from '../utils';
+import { LogOptions } from '../types';
+import { createInterpolate } from '../utils';
 import { rPretty } from '../tick-methods/r-pretty';
 
 const reflect = (f) => {
@@ -33,7 +33,7 @@ const transformPow = (base: number, shouldReflect: boolean) => {
  * 构造一个线性的对数比例尺
  */
 export class Log extends Continuous<LogOptions> {
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions(): LogOptions {
     return {
       domain: [1, 10],
       range: [0, 1],
@@ -41,35 +41,16 @@ export class Log extends Continuous<LogOptions> {
       interpolate: createInterpolate,
       tickMethod: rPretty,
       tickCount: 5,
-    } as PowOptions;
+    };
   }
 
-  protected chooseTransform() {
+  protected chooseTransforms() {
     const { base, domain } = this.options;
-    const isReflect = domain[0] < 0;
-    return transformLog(base, isReflect);
-  }
-
-  protected chooseUntransform() {
-    const { base, domain } = this.options;
-    const isReflect = domain[0] < 0;
-    return transformPow(base, isReflect);
+    const shouldReflect = domain[0] < 0;
+    return [transformLog(base, shouldReflect), transformPow(base, shouldReflect)];
   }
 
   public clone(): Log {
     return new Log(this.options);
-  }
-
-  protected nice(): void {
-    const { domain } = this.options;
-    this.options.domain = d3LinearNice(domain);
-  }
-
-  public getTicks() {
-    const { tickCount, domain, tickMethod, base } = this.options;
-    const lastIndex = domain.length - 1;
-    const dMin = domain[0];
-    const dMax = domain[lastIndex];
-    return tickMethod(dMin, dMax, tickCount, base);
   }
 }

--- a/src/scales/point.ts
+++ b/src/scales/point.ts
@@ -22,7 +22,7 @@ import { PointOptions, BandOptions } from '../types';
  */
 export class Point extends Band<PointOptions & BandOptions> {
   // 覆盖默认配置
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions() {
     return {
       domain: [],
       range: [0, 1],

--- a/src/scales/pow.ts
+++ b/src/scales/pow.ts
@@ -2,7 +2,7 @@ import { identity } from '@antv/util';
 import { Continuous, Transform } from './continuous';
 import { PowOptions } from '../types';
 import { Base } from './base';
-import { createInterpolate, d3LinearNice } from '../utils';
+import { createInterpolate } from '../utils';
 import { d3Linear } from '../tick-methods/d3-linear';
 
 const transformPow = (exponent: number) => {
@@ -28,7 +28,7 @@ const transformSqrt = (x: number) => {
  * 即 y = x ^ k 其中 k（指数）可以是任何实数。
  */
 export class Pow<O extends PowOptions> extends Continuous<O> {
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions() {
     return {
       domain: [0, 1],
       range: [0, 1],
@@ -47,33 +47,15 @@ export class Pow<O extends PowOptions> extends Continuous<O> {
     super(options as O);
   }
 
-  protected chooseTransform(): Transform {
+  protected chooseTransforms(): Transform[] {
     const { exponent } = this.options;
-    if (exponent === 1) {
-      return identity;
-    }
-    return exponent === 0.5 ? transformSqrt : transformPow(exponent);
-  }
-
-  protected chooseUntransform(): Transform {
-    const { exponent } = this.options;
-    return exponent === 1 ? identity : transformPowInvert(exponent);
+    if (exponent === 1) return [identity, identity];
+    const transform = exponent === 0.5 ? transformSqrt : transformPow(exponent);
+    const untransform = transformPowInvert(exponent);
+    return [transform, untransform];
   }
 
   public clone(): Base<O> {
     return new Pow<O>(this.options);
-  }
-
-  public getTicks() {
-    const { tickCount, domain, tickMethod } = this.options;
-    const lastIndex = domain.length - 1;
-    const min = domain[0];
-    const max = domain[lastIndex];
-    return tickMethod(min, max, tickCount);
-  }
-
-  protected nice() {
-    const { domain } = this.options;
-    this.options.domain = d3LinearNice(domain);
   }
 }

--- a/src/scales/quantile.ts
+++ b/src/scales/quantile.ts
@@ -11,14 +11,14 @@ export class Quantile extends Threshold<QuantileOptions> {
   // 这里不能给 thresholds 赋值，否者会编译后，会在 constructor 后面执行：this.thresholds = []
   private thresholds: QuantileOptions['domain'];
 
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions(): QuantileOptions {
     return {
       domain: [],
       range: [],
       tickCount: 5,
       unknown: undefined,
       tickMethod: wilkinsonExtended,
-    } as QuantileOptions;
+    };
   }
 
   constructor(options?: QuantileOptions) {

--- a/src/scales/quantize.ts
+++ b/src/scales/quantize.ts
@@ -28,7 +28,7 @@ export class Quantize extends Threshold<QuantizeOptions> {
     return this.thresholds;
   }
 
-  protected niceDomain() {
+  protected nice() {
     const { nice, domain } = this.options;
     if (nice) {
       this.options.domain = d3LinearNice(domain);
@@ -36,7 +36,7 @@ export class Quantize extends Threshold<QuantizeOptions> {
   }
 
   protected rescale() {
-    this.niceDomain();
+    this.nice();
 
     const { range, domain } = this.options;
     const [x0, x1] = domain;

--- a/src/scales/quantize.ts
+++ b/src/scales/quantize.ts
@@ -10,14 +10,14 @@ export class Quantize extends Threshold<QuantizeOptions> {
   // 这里不能给 thresholds 赋值，否者会编译后，会在 constructor 后面执行：this.thresholds = []
   private thresholds: QuantizeOptions['domain'];
 
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions(): QuantizeOptions {
     return {
       domain: [0, 1],
       range: [0.5],
       nice: false,
       tickCount: 5,
       tickMethod: wilkinsonExtended,
-    } as QuantizeOptions;
+    };
   }
 
   constructor(options?: QuantizeOptions) {

--- a/src/scales/sqrt.ts
+++ b/src/scales/sqrt.ts
@@ -4,7 +4,7 @@ import { SqrtOptions, PowOptions } from '../types';
 import { Pow } from './pow';
 
 export class Sqrt extends Pow<SqrtOptions & PowOptions> {
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions() {
     return {
       domain: [0, 1],
       range: [0, 1],

--- a/src/scales/threshold.ts
+++ b/src/scales/threshold.ts
@@ -10,7 +10,7 @@ export class Threshold<O extends ThresholdOptions> extends Base<O> {
   /** threshold 的数量 */
   protected n: number;
 
-  protected getOverrideDefaultOptions() {
+  protected getDefaultOptions() {
     return {
       domain: [0.5],
       range: [0, 1],
@@ -19,7 +19,6 @@ export class Threshold<O extends ThresholdOptions> extends Base<O> {
 
   constructor(options?: ThresholdOptions) {
     super(options as O);
-    this.rescale();
   }
 
   /**
@@ -43,11 +42,6 @@ export class Threshold<O extends ThresholdOptions> extends Base<O> {
 
   public clone() {
     return new Threshold<O>(this.options);
-  }
-
-  public update(options?: O) {
-    super.update(options);
-    this.rescale();
   }
 
   protected rescale() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,11 +63,26 @@ export type ContinuousOptions = BaseOptions<number> &
 /** Linear 比例尺的选项 */
 export type LinearOptions = ContinuousOptions;
 
+/** Pow 比例尺的选项 */
+export type PowOptions = ContinuousOptions & {
+  /** 指数 */
+  exponent?: number;
+};
+
+/** Sqrt 比例尺的选项 */
+export type SqrtOptions = Omit<PowOptions, 'exponent'>;
+
+/** Log 比例尺的选项 */
+export type LogOptions = ContinuousOptions & {
+  /** 底数 */
+  base?: number;
+};
+
 /** OrdinalOptions 比例尺的选项 */
 export type OrdinalOptions = BaseOptions<number | string> & { compare?: Comparator };
 
 /** 详细请参阅 scale/band.ts */
-export type BandOptions = BaseOptions<number | string, number> & { compare?: Comparator } & {
+export type BandOptions = BaseOptions<number | string, number> & {
   /** 是否取整 */
   round?: boolean;
   /** 内部边距 */
@@ -78,6 +93,8 @@ export type BandOptions = BaseOptions<number | string, number> & { compare?: Com
   padding?: number;
   /** 对齐，取值为 0 - 1 的整数，例如 0.5 表示居中 */
   align?: number;
+  /** 比较器，用于对 domain 进行排序 */
+  compare?: Comparator;
 };
 
 /** Point 比例尺的选项 */
@@ -94,18 +111,3 @@ export type QuantizeOptions = ThresholdOptions &
 
 /** Quantile 比例尺的选项 */
 export type QuantileOptions = ThresholdOptions & TickOptions;
-
-/** Pow 比例尺的选项 */
-export type PowOptions = ContinuousOptions & {
-  /** 指数 */
-  exponent?: number;
-};
-
-/** Sqrt 比例尺的选项 */
-export type SqrtOptions = Omit<PowOptions, 'exponent'>;
-
-/** Log 比例尺的选项 */
-export type LogOptions = ContinuousOptions & {
-  /** 底数 */
-  base?: number;
-};


### PR DESCRIPTION
重构了一下代码，抽取了一些复用逻辑，主要的修改如下：

- 梳理了所有 scale 的使用流程：初始化和更新 options 的时候，根据传入的 options 和已有的 options 更新内部状态 rescale，然后根据内部的状态去 map 和 invert。
- 将 getOverrideDefaultOptions 变成了 getDefaultOptions，每个比例尺在 getDefaultOptions 返回完整的默认值，这样可读性更强。
- continuous 类的比例尺
  - nice 和 getTicks 都提取到 continuous 比例尺中。
  - chooseTransform 和 chooseUnTransform 的合并。