### PR TITLE
feat/scales

### DIFF
--- a/__tests__/unit/scales/continuous.spec.ts
+++ b/__tests__/unit/scales/continuous.spec.ts
@@ -134,14 +134,6 @@ describe('Continuous', () => {
     expect(s.invert(1000)).toEqual(10);
   });
 
-  // test('map(x) accepts color range', () => {
-  //   expect(new Scale({ range: ['red', 'blue'] }).map(0.5)).toBe('rgb(128, 0, 128)');
-  //   expect(new Scale({ range: ['#f00', '#00f'] }).map(0.5)).toBe('rgb(128, 0, 128)');
-  //   expect(new Scale({ range: ['rgb(255,0,0)', 'hsl(240,100%,50%)'] }).map(0.5)).toBe('rgb(128, 0, 128)');
-  //   expect(new Scale({ range: ['rgb(100%,0%,0%)', 'hsl(240,100%,50%)'] }).map(0.5)).toBe('rgb(128, 0, 128)');
-  //   expect(new Scale({ range: ['hsl(0,100%,50%)', 'hsl(240,100%,50%)'] }).map(0.5)).toBe('rgb(128, 0, 128)');
-  // });
-
   test('map(x) change descending domain to ascending', () => {
     const s = new Scale({
       domain: [10, 0],

--- a/__tests__/unit/scales/continuous.spec.ts
+++ b/__tests__/unit/scales/continuous.spec.ts
@@ -211,11 +211,7 @@ describe('Continuous', () => {
 
   test('options.interpolate sets a custom interpolator factory', () => {
     // y^2 = mx + b
-    const interpolate: Interpolate<number | string> = (a, b) => (t) => {
-      const a0 = a as number;
-      const b0 = b as number;
-      return Math.sqrt(a0 * a0 * (1 - t) + b0 * b0 * t);
-    };
+    const interpolate: Interpolate<number> = (a, b) => (t) => Math.sqrt(a * a * (1 - t) + b * b * t);
 
     const s = new Scale({
       domain: [0, 4],

--- a/__tests__/unit/scales/continuous.spec.ts
+++ b/__tests__/unit/scales/continuous.spec.ts
@@ -134,6 +134,14 @@ describe('Continuous', () => {
     expect(s.invert(1000)).toEqual(10);
   });
 
+  // test('map(x) accepts color range', () => {
+  //   expect(new Scale({ range: ['red', 'blue'] }).map(0.5)).toBe('rgb(128, 0, 128)');
+  //   expect(new Scale({ range: ['#f00', '#00f'] }).map(0.5)).toBe('rgb(128, 0, 128)');
+  //   expect(new Scale({ range: ['rgb(255,0,0)', 'hsl(240,100%,50%)'] }).map(0.5)).toBe('rgb(128, 0, 128)');
+  //   expect(new Scale({ range: ['rgb(100%,0%,0%)', 'hsl(240,100%,50%)'] }).map(0.5)).toBe('rgb(128, 0, 128)');
+  //   expect(new Scale({ range: ['hsl(0,100%,50%)', 'hsl(240,100%,50%)'] }).map(0.5)).toBe('rgb(128, 0, 128)');
+  // });
+
   test('map(x) change descending domain to ascending', () => {
     const s = new Scale({
       domain: [10, 0],
@@ -211,7 +219,11 @@ describe('Continuous', () => {
 
   test('options.interpolate sets a custom interpolator factory', () => {
     // y^2 = mx + b
-    const interpolate: Interpolate = (a, b) => (t) => Math.sqrt(a * a * (1 - t) + b * b * t);
+    const interpolate: Interpolate<number | string> = (a, b) => (t) => {
+      const a0 = a as number;
+      const b0 = b as number;
+      return Math.sqrt(a0 * a0 * (1 - t) + b0 * b0 * t);
+    };
 
     const s = new Scale({
       domain: [0, 4],

--- a/__tests__/unit/scales/continuous.spec.ts
+++ b/__tests__/unit/scales/continuous.spec.ts
@@ -1,6 +1,6 @@
 import { identity } from '@antv/util';
-import { createInterpolate } from '../../../src/utils';
-import { Interpolate, ContinuousOptions, Continuous } from '../../../src';
+import { createInterpolateNumber } from '../../../src/utils';
+import { Interpolate, ContinuousOptions, Continuous, Interpolates } from '../../../src';
 
 describe('Continuous', () => {
   type ScaleOptions = ContinuousOptions;
@@ -42,7 +42,7 @@ describe('Continuous', () => {
       tickCount: 5,
     });
 
-    expect(interpolate).toEqual(createInterpolate);
+    expect(interpolate).toEqual(createInterpolateNumber);
   });
 
   test('Continuous(options) override defaults', () => {
@@ -215,6 +215,22 @@ describe('Continuous', () => {
       const a0 = a as number;
       const b0 = b as number;
       return Math.sqrt(a0 * a0 * (1 - t) + b0 * b0 * t);
+    };
+
+    const s = new Scale({
+      domain: [0, 4],
+      range: [0, 2],
+      interpolate,
+    });
+
+    expect(s.map(0)).toBe(0);
+    expect(s.map(4)).toBe(2);
+  });
+
+  test('export type Interpolates', () => {
+    // y^2 = mx + b
+    const interpolate: Interpolates = (a: number, b: number) => (t) => {
+      return Math.sqrt(a * a * (1 - t) + b * b * t);
     };
 
     const s = new Scale({

--- a/__tests__/unit/scales/identity.spec.ts
+++ b/__tests__/unit/scales/identity.spec.ts
@@ -68,6 +68,21 @@ describe('Identity', () => {
     });
 
     expect(s.getTicks()).toEqual([]);
+
+    s.update({
+      domain: [1, 'a'],
+    });
+    expect(s.getTicks()).toEqual([]);
+
+    s.update({
+      domain: ['a', 1],
+    });
+    expect(s.getTicks()).toEqual([]);
+
+    s.update({
+      domain: ['a', 'b'],
+    });
+    expect(s.getTicks()).toEqual([]);
   });
 
   test('clone() returns a scale belong to same class', () => {

--- a/__tests__/unit/scales/identity.spec.ts
+++ b/__tests__/unit/scales/identity.spec.ts
@@ -34,6 +34,9 @@ describe('Identity', () => {
     expect(x.map(1)).toBe(1);
     expect(x.map(-0.5)).toBe(-0.5);
     expect(x.map(2.5)).toBe(2.5);
+    expect(x.map('1')).toBe('1');
+    expect(x.map([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(x.map({ a: 1, b: 1 })).toEqual({ a: 1, b: 1 });
   });
 
   test('map(falsy) to option.unknown', () => {

--- a/__tests__/unit/scales/linear.spec.ts
+++ b/__tests__/unit/scales/linear.spec.ts
@@ -1,4 +1,4 @@
-import { Linear, TickMethod } from '../../../src';
+import { createInterpolateColor as color, Linear, TickMethod, createInterpolateValue as value } from '../../../src';
 import { d3Ticks } from '../../../src/tick-methods/d3-ticks';
 
 describe('Linear Scale Test', () => {
@@ -78,6 +78,35 @@ describe('Linear Scale Test', () => {
     expect(scale.invert(1000)).toStrictEqual(10);
     expect(scale.invert(18100)).toStrictEqual(100);
     expect(scale.invert(-100)).toStrictEqual(-10);
+  });
+
+  test('map(x) use color interpolate', () => {
+    expect(new Linear({ range: ['red', 'blue'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(new Linear({ range: ['#f00', '#00f'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(new Linear({ range: ['rgb(255,0,0)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
+      'rgba(127.5, 0, 127.5, 1)'
+    );
+    expect(new Linear({ range: ['rgb(100%,0%,0%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
+      'rgba(127.5, 0, 127.5, 1)'
+    );
+    expect(new Linear({ range: ['hsl(0,100%,50%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
+      'rgba(127.5, 0, 127.5, 1)'
+    );
+  });
+
+  test('map(x) use value interpolate ', () => {
+    expect(new Linear({ range: ['red', 'blue'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(new Linear({ range: ['#f00', '#00f'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(new Linear({ range: ['rgb(255,0,0)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
+      'rgba(127.5, 0, 127.5, 1)'
+    );
+    expect(new Linear({ range: ['rgb(100%,0%,0%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
+      'rgba(127.5, 0, 127.5, 1)'
+    );
+    expect(new Linear({ range: ['hsl(0,100%,50%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
+      'rgba(127.5, 0, 127.5, 1)'
+    );
+    expect(new Linear({ range: [0, 1], interpolate: value }).map(0.5)).toBe(0.5);
   });
 
   test('test getTicks()', () => {

--- a/__tests__/unit/scales/linear.spec.ts
+++ b/__tests__/unit/scales/linear.spec.ts
@@ -81,30 +81,30 @@ describe('Linear Scale Test', () => {
   });
 
   test('map(x) use color interpolate', () => {
-    expect(new Linear({ range: ['red', 'blue'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(new Linear({ range: ['#f00', '#00f'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(new Linear({ range: ['red', 'blue'], interpolate: color }).map(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(new Linear({ range: ['#f00', '#00f'], interpolate: color }).map(0.5)).toBe('rgba(128, 0, 128, 1)');
     expect(new Linear({ range: ['rgb(255,0,0)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
-      'rgba(127.5, 0, 127.5, 1)'
+      'rgba(128, 0, 128, 1)'
     );
     expect(new Linear({ range: ['rgb(100%,0%,0%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
-      'rgba(127.5, 0, 127.5, 1)'
+      'rgba(128, 0, 128, 1)'
     );
     expect(new Linear({ range: ['hsl(0,100%,50%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
-      'rgba(127.5, 0, 127.5, 1)'
+      'rgba(128, 0, 128, 1)'
     );
   });
 
   test('map(x) use value interpolate ', () => {
-    expect(new Linear({ range: ['red', 'blue'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(new Linear({ range: ['#f00', '#00f'], interpolate: color }).map(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(new Linear({ range: ['rgb(255,0,0)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
-      'rgba(127.5, 0, 127.5, 1)'
+    expect(new Linear({ range: ['red', 'blue'], interpolate: value }).map(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(new Linear({ range: ['#f00', '#00f'], interpolate: value }).map(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(new Linear({ range: ['rgb(255,0,0)', 'hsl(240,100%,50%)'], interpolate: value }).map(0.5)).toBe(
+      'rgba(128, 0, 128, 1)'
     );
-    expect(new Linear({ range: ['rgb(100%,0%,0%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
-      'rgba(127.5, 0, 127.5, 1)'
+    expect(new Linear({ range: ['rgb(100%,0%,0%)', 'hsl(240,100%,50%)'], interpolate: value }).map(0.5)).toBe(
+      'rgba(128, 0, 128, 1)'
     );
-    expect(new Linear({ range: ['hsl(0,100%,50%)', 'hsl(240,100%,50%)'], interpolate: color }).map(0.5)).toBe(
-      'rgba(127.5, 0, 127.5, 1)'
+    expect(new Linear({ range: ['hsl(0,100%,50%)', 'hsl(240,100%,50%)'], interpolate: value }).map(0.5)).toBe(
+      'rgba(128, 0, 128, 1)'
     );
     expect(new Linear({ range: [0, 1], interpolate: value }).map(0.5)).toBe(0.5);
   });

--- a/__tests__/unit/scales/ordinal.spec.ts
+++ b/__tests__/unit/scales/ordinal.spec.ts
@@ -90,6 +90,28 @@ describe('ordinal scale', () => {
     expect(date.invert(new Date('2020-02-01'))).toStrictEqual('a');
   });
 
+  test('map object', () => {
+    const scale = new Ordinal({
+      domain: [{ a: 1 }, { a: 2 }, { a: 3 }],
+      range: [new Date('2020-02-01'), new Date('2020-02-02'), new Date('2020-02-03')],
+    });
+
+    expect(scale.map({ a: 1 })).toStrictEqual(new Date('2020-02-01'));
+    expect(scale.map({ a: 2 })).toStrictEqual(new Date('2020-02-02'));
+    expect(scale.map({ a: 3 })).toStrictEqual(new Date('2020-02-03'));
+  });
+
+  test('invert object', () => {
+    const scale = new Ordinal({
+      range: [{ a: 1 }, { a: 2 }, { a: 3 }],
+      domain: [new Date('2020-02-01'), new Date('2020-02-02'), new Date('2020-02-03')],
+    });
+
+    expect(scale.invert({ a: 1 })).toStrictEqual(new Date('2020-02-01'));
+    expect(scale.invert({ a: 2 })).toStrictEqual(new Date('2020-02-02'));
+    expect(scale.invert({ a: 3 })).toStrictEqual(new Date('2020-02-03'));
+  });
+
   test('update scale', () => {
     const scale = new Ordinal({
       domain: ['A', 'B', 'C'],

--- a/__tests__/unit/scales/time.spec.ts
+++ b/__tests__/unit/scales/time.spec.ts
@@ -1,6 +1,6 @@
 import { Time, TimeOptions } from '../../../src';
 import { d3Time } from '../../../src/tick-methods/d3-time';
-import { createInterpolate, d3TimeNice } from '../../../src/utils';
+import { createInterpolateNumber, d3TimeNice } from '../../../src/utils';
 
 function UTC(
   year: number,
@@ -32,7 +32,7 @@ describe('Time', () => {
     });
 
     expect(tickMethod).toBe(d3Time);
-    expect(interpolate).toBe(createInterpolate);
+    expect(interpolate).toBe(createInterpolateNumber);
   });
 
   test('map(x) coerces x to timestamp if x is Date Object', () => {

--- a/__tests__/unit/utils/color.spec.ts
+++ b/__tests__/unit/utils/color.spec.ts
@@ -1,0 +1,35 @@
+import { string2rbg } from '../../../src/utils/color';
+
+describe('string2rbg', () => {
+  test('change css named color string to rgba', () => {
+    expect(string2rbg('red')).toEqual([255, 0, 0, 1]);
+    expect(string2rbg('blue')).toEqual([0, 0, 255, 1]);
+    expect(string2rbg('yellow')).toEqual([255, 255, 0, 1]);
+  });
+
+  test('change css hex color string to rgba', () => {
+    expect(string2rbg('#FFF')).toEqual([255, 255, 255, 1]);
+    expect(string2rbg('#FFFA')).toEqual([255, 255, 255, 0.6666666666666666]);
+    expect(string2rbg('#FFFFFFAA')).toEqual([255, 255, 255, 0.6666666666666666]);
+  });
+
+  test('change css rgba color string to rgba', () => {
+    expect(string2rbg('rgb(0, 145, 20)')).toEqual([0, 145, 20, 1]);
+    expect(string2rbg('rgba(0, 145, 20, 0.5)')).toEqual([0, 145, 20, 0.5]);
+  });
+
+  test('change css hsl color string to rgba', () => {
+    expect(string2rbg('hsl(60, 100%, 20%)')).toEqual([101.99999999999997, 102, 0, 1]);
+    expect(string2rbg('hsl(60, 0%, 100%)')).toEqual([255, 255, 255, 1]);
+    expect(string2rbg('hsl(20, 20%, 100%)')).toEqual([255, 255, 255, 1]);
+    expect(string2rbg('hsl(359, 20%, 100%)')).toEqual([255, 255, 255, 1]);
+    expect(string2rbg('hsl(420, 20%, 80%)')).toEqual([214.2, 214.2, 193.80000000000004, 1]);
+    expect(string2rbg('hsla(60, 100%, 20%, 0.4)')).toEqual([101.99999999999997, 102, 0, 0.4]);
+  });
+
+  test('change invalid css hsl color string to null', () => {
+    expect(string2rbg('read')).toBeNull();
+    expect(string2rbg('glue')).toBeNull();
+    expect(string2rbg('hwb(60, 3%, 60%)')).toBeNull();
+  });
+});

--- a/__tests__/unit/utils/interpolate.spec.ts
+++ b/__tests__/unit/utils/interpolate.spec.ts
@@ -18,11 +18,11 @@ describe('interpolate', () => {
   });
 
   test('createInterpolateColor(a, b) returns a color linear interpolator with valid color input', () => {
-    expect(createInterpolateColor('red', 'blue')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateColor('#f00', '#00f')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateColor('rgb(255,0,0)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateColor('rgb(100%,0%,0%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateColor('hsl(0,100%,50%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateColor('red', 'blue')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateColor('#f00', '#00f')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateColor('rgb(255,0,0)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateColor('rgb(100%,0%,0%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateColor('hsl(0,100%,50%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(128, 0, 128, 1)');
 
     expect(createInterpolateColor('reed', 'hsl(240,100%,50%)')(0.5)).toBe('hsl(240,100%,50%)');
     expect(createInterpolateColor('hsl(240,100%,50%)', 'reed')(0.5)).toBe('hsl(240,100%,50%)');
@@ -34,11 +34,11 @@ describe('interpolate', () => {
     expect(createInterpolateValue(0, 10)(0.5)).toBe(5);
     expect(createInterpolateValue(0, 10)(0.95)).toBe(9.5);
 
-    expect(createInterpolateValue('red', 'blue')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateValue('#f00', '#00f')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateValue('rgb(255,0,0)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateValue('rgb(100%,0%,0%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
-    expect(createInterpolateValue('hsl(0,100%,50%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateValue('red', 'blue')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateValue('#f00', '#00f')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateValue('rgb(255,0,0)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateValue('rgb(100%,0%,0%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(128, 0, 128, 1)');
+    expect(createInterpolateValue('hsl(0,100%,50%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(128, 0, 128, 1)');
 
     expect(createInterpolateValue('reed', 'hsl(240,100%,50%)')(0.5)).toBe('hsl(240,100%,50%)');
     expect(createInterpolateValue('hsl(240,100%,50%)', 'reed')(0.5)).toBe('hsl(240,100%,50%)');

--- a/__tests__/unit/utils/interpolate.spec.ts
+++ b/__tests__/unit/utils/interpolate.spec.ts
@@ -1,8 +1,9 @@
-import { createInterpolateRound, createInterpolate } from '../../../src/utils';
+import { createInterpolateNumber, createInterpolateColor, createInterpolateValue } from '../../../src';
+import { createInterpolateRound } from '../../../src/utils';
 
 describe('interpolate', () => {
-  test('createInterpolate(a, b) returns a linear interpolator', () => {
-    const interpolate = createInterpolate(0, 10);
+  test('createInterpolateNumber(a, b) returns a linear interpolator', () => {
+    const interpolate = createInterpolateNumber(0, 10);
 
     expect(interpolate(0.1)).toBe(1);
     expect(interpolate(0.5)).toBe(5);
@@ -14,5 +15,34 @@ describe('interpolate', () => {
     expect(interpolateRound(0.12)).toBe(1);
     expect(interpolateRound(0.14)).toBe(1);
     expect(interpolateRound(0.15)).toBe(2);
+  });
+
+  test('createInterpolateColor(a, b) returns a color linear interpolator with valid color input', () => {
+    expect(createInterpolateColor('red', 'blue')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateColor('#f00', '#00f')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateColor('rgb(255,0,0)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateColor('rgb(100%,0%,0%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateColor('hsl(0,100%,50%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+
+    expect(createInterpolateColor('reed', 'hsl(240,100%,50%)')(0.5)).toBe('hsl(240,100%,50%)');
+    expect(createInterpolateColor('hsl(240,100%,50%)', 'reed')(0.5)).toBe('hsl(240,100%,50%)');
+    expect(createInterpolateColor('reed', 'hhh')(0.5)).toBe('hhh');
+  });
+
+  test('createInterpolateValue(a, b) returns a linear interpolator ', () => {
+    expect(createInterpolateValue(0, 10)(0.1)).toBe(1);
+    expect(createInterpolateValue(0, 10)(0.5)).toBe(5);
+    expect(createInterpolateValue(0, 10)(0.95)).toBe(9.5);
+
+    expect(createInterpolateValue('red', 'blue')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateValue('#f00', '#00f')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateValue('rgb(255,0,0)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateValue('rgb(100%,0%,0%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+    expect(createInterpolateValue('hsl(0,100%,50%)', 'hsl(240,100%,50%)')(0.5)).toBe('rgba(127.5, 0, 127.5, 1)');
+
+    expect(createInterpolateValue('reed', 'hsl(240,100%,50%)')(0.5)).toBe('hsl(240,100%,50%)');
+    expect(createInterpolateValue('hsl(240,100%,50%)', 'reed')(0.5)).toBe('hsl(240,100%,50%)');
+    expect(createInterpolateValue('reed', 'hhh')(0.5)).toBe('hhh');
+    expect(createInterpolateValue('reed', 1)(0.5)).toBe('reed');
   });
 });

--- a/docs/api/interpolators.md
+++ b/docs/api/interpolators.md
@@ -30,9 +30,9 @@ const x = new Linear({
   range: ['red', 'blue'],
 });
 
-x.map(0.5); // rgba(127.5, 0, 127.5, 1);
+x.map(0.5); // rgba(128, 0, 128, 1);
 
-createInterpolateNumber('red', 'blue')(0.5); // rgba(127.5, 0, 127.5, 1);
+createInterpolateNumber('red', 'blue')(0.5); // rgba(128, 0, 128, 1);
 ```
 
 <a name="createInterpolateNumber" href="#createInterpolateNumber">#</a> **createInterpolateNumber**<i>(a: number, b: number) => Interpolate</i>
@@ -53,6 +53,6 @@ x.update({
   range: ['hsl(0, 100%, 50%)', 'hsl(240, 100%, 50%)'],
 });
 
-x.map(0.5); // rgba(127.5, 0, 127.5, 1)
+x.map(0.5); // rgba(128, 0, 128, 1)
 createInterpolateValue('hsl(0, 100%, 50%)', 'hsl(240, 100%, 50%)')(0.5); // 0.5;
 ```

--- a/docs/api/interpolators.md
+++ b/docs/api/interpolators.md
@@ -1,0 +1,58 @@
+# Interpolators
+
+Built-in interpolator factories for continuous scale.
+
+## Usage
+
+<a name="createInterpolateNumber" href="#createInterpolateNumber">#</a> **createInterpolateNumber**<i>(a: number, b: number) => Interpolate</i>
+
+The default interpolate factory for continuous scales which returns a number interpolator.
+
+```ts
+import { Linear, createInterpolateNumber } from '@antv/scale';
+
+const x = new Linear({ interpolate: createInterpolateNumber });
+
+x.map(0.5); // 0.5;
+
+createInterpolateNumber(0, 1)(0.5); // 0.5;
+```
+
+<a name="createInterpolateColor" href="#createInterpolateColor">#</a> **createInterpolateColor**<i>(a: string, b: string) => Interpolate</i>
+
+The css color interpolate factory for continuous scales which returns a color interpolator.
+
+```ts
+import { Linear, createInterpolateColor } from '@antv/scale';
+
+const x = new Linear({
+  interpolate: createInterpolateColor,
+  range: ['red', 'blue'],
+});
+
+x.map(0.5); // rgba(127.5, 0, 127.5, 1);
+
+createInterpolateNumber('red', 'blue')(0.5); // rgba(127.5, 0, 127.5, 1);
+```
+
+<a name="createInterpolateNumber" href="#createInterpolateNumber">#</a> **createInterpolateNumber**<i>(a: number, b: number) => Interpolate</i>
+
+The value interpolate factory which can interpolate numbers and colors depending on input type.
+
+```ts
+import { Linear, createInterpolateValue } from '@antv/scale';
+
+const x = new Linear({
+  interpolate: createInterpolateValue,
+});
+
+x.map(0.5); // 0.5;
+createInterpolateValue(0, 1)(0.5); // 0.5;
+
+x.update({
+  range: ['hsl(0, 100%, 50%)', 'hsl(240, 100%, 50%)'],
+});
+
+x.map(0.5); // rgba(127.5, 0, 127.5, 1)
+createInterpolateValue('hsl(0, 100%, 50%)', 'hsl(240, 100%, 50%)')(0.5); // 0.5;
+```

--- a/docs/api/readme.md
+++ b/docs/api/readme.md
@@ -21,7 +21,7 @@ Map a continuous, quantitative domain to a continuous range.
 - [Pow](./scales/pow.md) - Similar to linear scales, except an exponential transform is applied to the input domain value before the output range value is computed.
 - [Sqrt](./scales/sqrt.md) - A special case of pow scales with exponent fixed to 0.5.
 - [Time](./scales/time.md) - Similar to linear scales, but have a have a temporal domain.
-  
+
 ### Distribution
 
 Map a continuous, quantitative domain to a discrete range.
@@ -40,11 +40,19 @@ Map a discrete domain to a discrete or continuous range.
 
 ## Tick Methods
 
-Method for computing representative values.
+Methods for computing representative values.
 
 - [D3 Ticks](./tick-methods.md#d3-ticks) - D3 ticks in d3-array.
 - [R Pretty](./tick-methods.md#r-pretty) - An algorithm for positioning tick labels on axes in R language.
 - [Wilkinson Extended](./tick-methods.md#wilkinson-extended) - An extension of Wilkinson's algorithm for positioning tick labels on axes.
+
+## Interpolators
+
+Built-in interpolator factories for continuous scale.
+
+- [createInterpolateNumber](./interpolators.md#createInterpolateNumber) - Returns a number interpolator.
+- [createInterpolateColor](./interpolators.md#createInterpolateColor) - Returns a color interpolator.
+- [createInterpolateValue](./interpolators.md#createInterpolateValue) - Returns a interpolator which can interpolate numbers and colors depending on input type.
 
 ## Constants
 

--- a/docs/api/scales/identity.md
+++ b/docs/api/scales/identity.md
@@ -55,19 +55,19 @@ x3.getTicks(); // [2, 4.5, 7, 9.5, 12, 14.5]
 
 | Key | Description | Type | Default|  
 | ----| ----------- | -----| -------|
-| domain | Sets the scale’s domain to the specified array of values. | `number[]` | `[0, 1]` |
-| range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
+| domain | Sets the scale’s domain to the specified array of values. | `any[]` | `[0, 1]` |
+| range | Sets the scale’s range to the specified array of values. | `any[]` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
 | tickCount | Sets approximately count representative values from the scale’s domain. **The specified `tickCount` in options is only a hint: the scale may return more or fewer values depending on the domain.** | `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(min: number, max: number, count: number) => number[]` | `d3-ticks` |
 
 ## Methods
 
-<a name="identity_map" href="#identity_map">#</a> **map**<i>(x: number): number | any</i>
+<a name="identity_map" href="#identity_map">#</a> **map**<i>(x: any): any</i>
 
 Given a value in the input domain, returns the corresponding value in the output range if it is not `undefined` (or `NaN`), otherwise `options.unknown`
 
-<a name="identity_invert" href="#identity_invert">#</a> **invert**<i>(x: number): number</i>
+<a name="identity_invert" href="#identity_invert">#</a> **invert**<i>(x: any): any</i>
 
 Given a value from the range, returns the corresponding value from the domain.
 

--- a/docs/api/scales/linear.md
+++ b/docs/api/scales/linear.md
@@ -90,6 +90,19 @@ x.map(-1) // 0
 x.map(2) // 1
 ```
 
+- Change range interpolator
+
+```ts
+import { Linear, createInterpolateColor } from '@antv/scale';
+
+const color = new Linear({
+  range: ['red', 'blue'],
+  interpolate: createInterpolateColor
+});
+
+x.map(0.5) // 'rgba(127.5, 0, 127.5, 1)'
+```
+
 - Customize range interpolator
   
 ```ts
@@ -154,7 +167,7 @@ x3.getTicks(); // [2, 4.5, 7, 9.5, 12, 14.5]
 | Key | Description | Type | Default|  
 | ----| ----------- | -----| -------|
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` | `[0, 1]` |
-| range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
+| range | Sets the scale’s range to the specified array of values. | `<code>number[] &#124; string[]</code>` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
 | tickCount | Sets approximately count representative values from the scale’s domain. **The specified `tickCount` in options is only a hint: the scale may return more or fewer values depending on the domain.**| `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(min: number, max: number, count: number) => number[]` | `d3-ticks` |

--- a/docs/api/scales/log.md
+++ b/docs/api/scales/log.md
@@ -27,7 +27,7 @@ More usages reference [linear scale](./linear.md#usage).
 | Key | Description | Type | Default|  
 | ----| ----------- | -----| -------|
 | domain | Sets the scale’s domain to the specified array of values. **A log scale domain must be strictly-positive or strictly-negative; the domain must not include or cross zero.**  | `number[]` | `[0, 1]` |
-| range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
+| range | Sets the scale’s range to the specified array of values. | `<code>number[] &#124; string[]</code>` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
 | tickCount | Sets approximately count representative values from the scale’s domain. **The specified `tickCount` in options is only a hint: the scale may return more or fewer values depending on the domain.** | `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(min: number, max: number, count: number, base: number) => number[]` | `d3-ticks` |

--- a/docs/api/scales/ordinal.md
+++ b/docs/api/scales/ordinal.md
@@ -39,18 +39,18 @@ time.map('2021-04-20'); // 'C'
 
 | Key | Description | Type | Default|  
 | ----| ----------- | -----| -------|
-| domain | Sets the scale’s domain to the specified array of values. | <code>number[] &#124; string[] &#124; Date[] | `[]` |
-| range | Sets the scale’s range to the specified array of values. | <code>number[] &#124; string[]</code> | `[]` |
+| domain | Sets the scale’s domain to the specified array of values. | `any[]` | `[]` |
+| range | Sets the scale’s range to the specified array of values. |`any[]` | `[]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
 | compare | Sets the comparator for sorting the domain before mapping. | ```(a: string or number, b: string or number) => number```| `undefined` |
 
 ## Methods
 
-<a name="ordinal_map" href="#ordinal_map">#</a> **map**<i>(x: (number | string)[]): (number | string)[]</i>
+<a name="ordinal_map" href="#ordinal_map">#</a> **map**<i>(x: any): any</i>
 
 Given a value in the input domain, returns the corresponding value in the output range if it is not `undefined` (or `NaN`), otherwise `options.unknown`
 
-<a name="ordinal_invert" href="#ordinal_invert">#</a> **invert**<i>(x: (number | string) []): (number| string)[]</i>
+<a name="ordinal_invert" href="#ordinal_invert">#</a> **invert**<i>(x: any): any</i>
 
 Given a value from the range, returns the corresponding value from the domain.
 

--- a/docs/api/scales/pow.md
+++ b/docs/api/scales/pow.md
@@ -27,7 +27,7 @@ More usages reference [linear scale](./linear.md#usage).
 | Key | Description | Type | Default|  
 | ----| ----------- | -----| -------|
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` | `[0, 1]` |
-| range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
+| range | Sets the scale’s range to the specified array of values. | `<code>number[] &#124; string[]</code>` | `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
 | tickCount | Sets approximately count representative values from the scale’s domain. **The specified `tickCount` in options is only a hint: the scale may return more or fewer values depending on the domain.** | `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(min: number, max: number, count: number) => number[]` | `calculatePowTicks` |

--- a/docs/api/scales/sqrt.md
+++ b/docs/api/scales/sqrt.md
@@ -25,7 +25,7 @@ More usages reference [linear scale](./linear.md#usage).
 | Key | Description | Type | Default|  
 | ----| ----------- | -----| -------|
 | domain | Sets the scale’s domain to the specified array of values. | `number[]` | `[0, 1]` |
-| range | Sets the scale’s range to the specified array of values. | `number[]` | `[0, 1]` |
+| range | Sets the scale’s range to the specified array of values. | `<code>number[] &#124; string[]</code>`| `[0, 1]` |
 | unknown | Sets the output value of the scale for `undefined` (or `NaN`) input values. | `any` | `undefined` |
 | tickCount | Sets approximately count representative values from the scale’s domain. **The specified `tickCount` in options is only a hint: the scale may return more or fewer values depending on the domain.** | `number` | `5` |
 | tickMethod | Sets the method for computing representative values from the scale’s domain. | `(min: number, max: number, count: number) => number[]` | `calculatePowTicks` |

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^12.0.1",
+    "@rollup/plugin-commonjs": "^19.0.0",
     "@types/benchmark": "^2.1.0",
     "@types/color-string": "^1.5.0",
     "@types/jest": "^26.0.20",
@@ -83,12 +84,12 @@
   "limit-size": [
     {
       "path": "dist/scale.min.js",
-      "limit": "8 Kb",
+      "limit": "10 Kb",
       "gzip": true
     },
     {
       "path": "dist/scale.min.js",
-      "limit": "24 Kb"
+      "limit": "30 Kb"
     }
   ],
   "author": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^12.0.1",
     "@types/benchmark": "^2.1.0",
+    "@types/color-string": "^1.5.0",
     "@types/jest": "^26.0.20",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.19.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   },
   "dependencies": {
     "@antv/util": "^2.0.13",
+    "color-string": "^1.5.5",
     "fecha": "^4.2.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,18 +1,17 @@
+import commonjs from '@rollup/plugin-commonjs';
 import { uglify } from 'rollup-plugin-uglify';
 import resolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript';
 
-module.exports = [{
-  input: 'src/index.ts',
-  output: {
-    file: 'dist/scale.min.js',
-    name: 'Scale',
-    format: 'umd',
-    sourcemap: false,
+module.exports = [
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/scale.min.js',
+      name: 'Scale',
+      format: 'umd',
+      sourcemap: false,
+    },
+    plugins: [resolve(), typescript(), commonjs(), uglify()],
   },
-  plugins: [
-    resolve(),
-    typescript(),
-    uglify(),
-  ],
-}];
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export type {
 } from './types';
 
 // others
-export type { TickMethod, Interpolate, Comparator } from './types';
+export type { TickMethod, Interpolate, Comparator, Interpolates } from './types';
 
 // constants
 export {
@@ -54,3 +54,6 @@ export {
   DURATION_YEAR,
   DURATION_MONTH,
 } from './utils';
+
+// interpolators
+export { createInterpolateNumber, createInterpolateValue, createInterpolateColor } from './utils';

--- a/src/scales/continuous.ts
+++ b/src/scales/continuous.ts
@@ -127,7 +127,7 @@ export abstract class Continuous<O extends ContinuousOptions> extends Base<O> {
     return tickMethod(min, max, tickCount, ...rest);
   }
 
-  protected getTickMethodOptions() {
+  protected getTickMethodOptions(): [Domain<O>, Domain<O>, number, number?, boolean?] {
     const { domain, tickCount } = this.options;
     const min = domain[0];
     const max = domain[domain.length - 1];

--- a/src/scales/continuous.ts
+++ b/src/scales/continuous.ts
@@ -1,6 +1,6 @@
 import { identity } from '@antv/util';
 import { Base } from './base';
-import { ContinuousOptions, Domain, Range, NiceMethod } from '../types';
+import { ContinuousOptions, Domain, Range, NiceMethod, TickMethodOptions } from '../types';
 import {
   createInterpolate,
   createInterpolateRound,
@@ -127,7 +127,7 @@ export abstract class Continuous<O extends ContinuousOptions> extends Base<O> {
     return tickMethod(min, max, tickCount, ...rest);
   }
 
-  protected getTickMethodOptions(): [Domain<O>, Domain<O>, number, number?, boolean?] {
+  protected getTickMethodOptions(): TickMethodOptions {
     const { domain, tickCount } = this.options;
     const min = domain[0];
     const max = domain[domain.length - 1];

--- a/src/scales/continuous.ts
+++ b/src/scales/continuous.ts
@@ -2,7 +2,7 @@ import { identity } from '@antv/util';
 import { Base } from './base';
 import { ContinuousOptions, Domain, Range, NiceMethod, TickMethodOptions } from '../types';
 import {
-  createInterpolate,
+  createInterpolateNumber,
   createInterpolateRound,
   createClamp,
   createNormalize,
@@ -94,7 +94,7 @@ export abstract class Continuous<O extends ContinuousOptions> extends Base<O> {
       nice: false,
       clamp: false,
       round: false,
-      interpolate: createInterpolate,
+      interpolate: createInterpolateNumber,
       tickCount: 5,
     } as O;
   }
@@ -159,8 +159,8 @@ export abstract class Continuous<O extends ContinuousOptions> extends Base<O> {
   }
 
   protected composeInput(transform: Transform, untransform: Transform, clamp: Transform) {
-    const { domain, range, interpolate } = this.options;
-    const piecewise = choosePiecewise(range, domain.map(transform), interpolate);
+    const { domain, range } = this.options;
+    const piecewise = choosePiecewise(range, domain.map(transform), createInterpolateNumber);
     this.input = compose(untransform, clamp, piecewise);
   }
 }

--- a/src/scales/identity.ts
+++ b/src/scales/identity.ts
@@ -1,7 +1,7 @@
-import { isNumber } from '@antv/util';
 import { Base } from './base';
 import { IdentityOptions, Domain, Range } from '../types';
 import { wilkinsonExtended } from '../tick-methods/wilkinson-extended';
+import { isValid } from '../utils';
 
 export class Identity extends Base<IdentityOptions> {
   /**
@@ -24,7 +24,7 @@ export class Identity extends Base<IdentityOptions> {
    * @returns 输出值
    */
   public map(x: Domain<IdentityOptions>) {
-    return isNumber(x) && !Number.isNaN(x) ? x : this.options.unknown;
+    return isValid(x) ? x : this.options.unknown;
   }
 
   /**

--- a/src/scales/identity.ts
+++ b/src/scales/identity.ts
@@ -1,3 +1,4 @@
+import { isNumber } from '@antv/util';
 import { Base } from './base';
 import { IdentityOptions, Domain, Range } from '../types';
 import { wilkinsonExtended } from '../tick-methods/wilkinson-extended';
@@ -51,6 +52,7 @@ export class Identity extends Base<IdentityOptions> {
   public getTicks(): Range<IdentityOptions>[] {
     const { domain, tickCount, tickMethod } = this.options;
     const [min, max] = domain;
+    if (!isNumber(min) || !isNumber(max)) return [];
     return tickMethod(min, max, tickCount);
   }
 }

--- a/src/scales/linear.ts
+++ b/src/scales/linear.ts
@@ -2,7 +2,7 @@ import { identity } from '@antv/util';
 import { Continuous, Transform } from './continuous';
 import { LinearOptions } from '../types';
 import { Base } from './base';
-import { createInterpolate } from '../utils';
+import { createInterpolateValue } from '../utils';
 import { d3Ticks } from '../tick-methods/d3-ticks';
 
 /**
@@ -19,7 +19,7 @@ export class Linear extends Continuous<LinearOptions> {
       nice: false,
       clamp: false,
       round: false,
-      interpolate: createInterpolate,
+      interpolate: createInterpolateValue,
       tickMethod: d3Ticks,
       tickCount: 5,
     };

--- a/src/scales/log.ts
+++ b/src/scales/log.ts
@@ -1,5 +1,5 @@
 import { Continuous } from './continuous';
-import { LogOptions } from '../types';
+import { LogOptions, TickMethodOptions } from '../types';
 import { createInterpolate, logs, pows } from '../utils';
 import { d3Log } from '../tick-methods/d3-log';
 import { d3LogNice } from '../utils/d3-log-nice';
@@ -25,7 +25,7 @@ export class Log extends Continuous<LogOptions> {
     return d3LogNice;
   }
 
-  protected getTickMethodOptions() {
+  protected getTickMethodOptions(): TickMethodOptions<number> {
     const { domain, tickCount, base } = this.options;
     const min = domain[0];
     const max = domain[domain.length - 1];

--- a/src/scales/log.ts
+++ b/src/scales/log.ts
@@ -1,6 +1,6 @@
 import { Continuous } from './continuous';
 import { LogOptions, TickMethodOptions } from '../types';
-import { createInterpolate, logs, pows } from '../utils';
+import { createInterpolateValue, logs, pows } from '../utils';
 import { d3Log } from '../tick-methods/d3-log';
 import { d3LogNice } from '../utils/d3-log-nice';
 
@@ -15,7 +15,7 @@ export class Log extends Continuous<LogOptions> {
       domain: [1, 10],
       range: [0, 1],
       base: 10,
-      interpolate: createInterpolate,
+      interpolate: createInterpolateValue,
       tickMethod: d3Log,
       tickCount: 5,
     };

--- a/src/scales/ordinal.ts
+++ b/src/scales/ordinal.ts
@@ -54,6 +54,12 @@ function mapBetweenArrByMapIndex(options: MapBetweenArrOptions) {
   return to[mappedIndex % to.length];
 }
 
+function createKey(d: any) {
+  if (d instanceof Date) return (d: Date) => `${d}`;
+  if (typeof d === 'object') return (d: Object) => JSON.stringify(d);
+  return (d: number | string) => d;
+}
+
 /**
  * Ordinal 比例尺
  *
@@ -126,8 +132,8 @@ export class Ordinal<O extends OrdinalOptions = OrdinalOptions> extends Base<O> 
     const [d] = this.options.domain;
     const [r] = this.options.range;
 
-    this.domainKey = d instanceof Date ? (d) => `${d}` : (d) => d;
-    this.rangeKey = r instanceof Date ? (d) => `${d}` : (d) => d;
+    this.domainKey = createKey(d);
+    this.rangeKey = createKey(r);
 
     // 如果 rangeIndexMap 没有初始化，说明是在初始化阶段
     if (!this.rangeIndexMap) {

--- a/src/scales/pow.ts
+++ b/src/scales/pow.ts
@@ -2,7 +2,7 @@ import { identity } from '@antv/util';
 import { Continuous, Transform } from './continuous';
 import { PowOptions } from '../types';
 import { Base } from './base';
-import { createInterpolate } from '../utils';
+import { createInterpolateValue } from '../utils';
 import { d3Ticks } from '../tick-methods/d3-ticks';
 
 const transformPow = (exponent: number) => {
@@ -36,7 +36,7 @@ export class Pow<O extends PowOptions = PowOptions> extends Continuous<O> {
       clamp: false,
       round: false,
       exponent: 2,
-      interpolate: createInterpolate,
+      interpolate: createInterpolateValue,
       tickMethod: d3Ticks,
       tickCount: 5,
     } as O;

--- a/src/scales/sqrt.ts
+++ b/src/scales/sqrt.ts
@@ -1,4 +1,4 @@
-import { createInterpolate } from '../utils';
+import { createInterpolateValue } from '../utils';
 import { rPretty } from '../tick-methods/r-pretty';
 import { SqrtOptions, PowOptions } from '../types';
 import { Pow } from './pow';
@@ -11,7 +11,7 @@ export class Sqrt extends Pow<SqrtOptions & PowOptions> {
       nice: false,
       clamp: false,
       round: false,
-      interpolate: createInterpolate,
+      interpolate: createInterpolateValue,
       tickMethod: rPretty,
       tickCount: 5,
       exponent: 0.5,

--- a/src/scales/time.ts
+++ b/src/scales/time.ts
@@ -3,7 +3,7 @@ import { format } from 'fecha';
 import { Continuous } from './continuous';
 import { TickMethodOptions, TimeOptions } from '../types';
 import { d3Time } from '../tick-methods/d3-time';
-import { d3TimeNice, createInterpolate, localIntervalMap, utcIntervalMap, chooseNiceTimeMask } from '../utils';
+import { d3TimeNice, createInterpolateNumber, localIntervalMap, utcIntervalMap, chooseNiceTimeMask } from '../utils';
 
 function offset(date: Date): Date {
   const minuteOffset = date.getTimezoneOffset();
@@ -23,7 +23,7 @@ export class Time extends Continuous<TimeOptions> {
       unknown: undefined,
       clamp: false,
       tickMethod: d3Time,
-      interpolate: createInterpolate,
+      interpolate: createInterpolateNumber,
       mask: undefined,
       utc: false,
     };

--- a/src/scales/time.ts
+++ b/src/scales/time.ts
@@ -39,7 +39,7 @@ export class Time extends Continuous<TimeOptions> {
     return d3TimeNice;
   }
 
-  protected getTickMethodOptions() {
+  protected getTickMethodOptions(): [Date, Date, number, number, boolean] {
     const { domain, tickCount, tickInterval, utc } = this.options;
     const min = domain[0];
     const max = domain[domain.length - 1];

--- a/src/scales/time.ts
+++ b/src/scales/time.ts
@@ -1,7 +1,7 @@
 import { identity } from '@antv/util';
 import { format } from 'fecha';
 import { Continuous } from './continuous';
-import { TimeOptions } from '../types';
+import { TickMethodOptions, TimeOptions } from '../types';
 import { d3Time } from '../tick-methods/d3-time';
 import { d3TimeNice, createInterpolate, localIntervalMap, utcIntervalMap, chooseNiceTimeMask } from '../utils';
 
@@ -39,7 +39,7 @@ export class Time extends Continuous<TimeOptions> {
     return d3TimeNice;
   }
 
-  protected getTickMethodOptions(): [Date, Date, number, number, boolean] {
+  protected getTickMethodOptions(): TickMethodOptions<Date> {
     const { domain, tickCount, tickInterval, utc } = this.options;
     const min = domain[0];
     const max = domain[domain.length - 1];

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,34 +5,19 @@ export type TickMethod<T = number> = (min: T, max: T, n?: number, ...rest: any[]
 export type NiceMethod<T = number> = TickMethod<T>;
 
 /** 插值器工厂 */
-export type Interpolate = (a: number, b: number) => (t: number) => number;
+export type Interpolate<T = number> = (a: T, b: T) => (t: number) => T;
 
 /** 比较器 */
-export type Comparator = (a: string | number, b: string | number) => number;
+export type Comparator = (a: any, b: any) => number;
 
-/**
- * 所有比例尺选项的默认类型
- * D：定义域元素的类型
- * R：值域元素的类型
- */
-export type BaseOptions<D = any, R = D> = {
+/** 通用的配置 */
+export type BaseOptions = {
   /** 当需要映射的值不合法的时候，返回的值 */
   unknown?: any;
   /** 值域，默认为 [0, 1] */
-  range?: R[];
+  range?: any[];
   /** 定义域，默认为 [0, 1] */
-  domain?: D[];
-};
-
-/**
- * 支持 getTicks 的比例尺的选项
- * T：tickMethod 配置项的类型
- */
-export type TickOptions<T = number> = {
-  /** tick 个数，默认值为 5 */
-  tickCount?: number;
-  /** 计算 ticks 的算法 */
-  tickMethod?: TickMethod<T>;
+  domain?: any[];
 };
 
 /** 获得比例尺选项中定义域元素的类型 */
@@ -45,44 +30,114 @@ export type Range<O extends BaseOptions> = O['range'][number];
 export type Unknown<O extends BaseOptions> = O['unknown'];
 
 /** Identity 比例尺的选项 */
-export type IdentityOptions = BaseOptions<number> & TickOptions;
+
+/** Identity 比例尺的选项 */
+export type IdentityOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: any[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: any[];
+  /** tick 个数，默认值为 5 */
+  tickCount?: number;
+  /** 计算 ticks 的算法 */
+  tickMethod?: TickMethod<number>;
+};
 
 /** Constant 比例尺的选项 */
-export type ConstantOptions = BaseOptions<number | string> & TickOptions;
+export type ConstantOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: any[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: any[];
+  /** tick 个数，默认值为 5 */
+  tickCount?: number;
+  /** 计算 ticks 的算法 */
+  tickMethod?: TickMethod<number>;
+};
 
-/** Continuous 比例尺的选项 */
-export type ContinuousOptions<D = any, R = D> = BaseOptions<D, R> &
-  TickOptions<D> & {
-    /** 是否需要对定义域的范围进行优化 */
-    nice?: boolean;
-    /** 是否需要限制输入的范围在值域内 */
-    clamp?: boolean;
-    /** 是否需要对输出进行四舍五入 */
-    round?: boolean;
-    /** 插值器的工厂函数，返回一个对归一化后的输入在值域指定范围内插值的函数 */
-    interpolate?: Interpolate;
-  };
+/** Constant 比例尺的选项 */
+export type ContinuousOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: (number | string)[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: (number | Date)[];
+  /** tick 个数，默认值为 5 */
+  tickCount?: number;
+  /** 计算 ticks 的算法 */
+  tickMethod?: TickMethod<number | Date>;
+  /** 是否需要对定义域的范围进行优化 */
+  nice?: boolean;
+  /** 是否需要限制输入的范围在值域内 */
+  clamp?: boolean;
+  /** 是否需要对输出进行四舍五入 */
+  round?: boolean;
+  /** 插值器的工厂函数，返回一个对归一化后的输入在值域指定范围内插值的函数 */
+  interpolate?: Interpolate<number | string>;
+};
 
 /** Linear 比例尺的选项 */
-export type LinearOptions = ContinuousOptions<number>;
+export type LinearOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: (number | string)[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: number[];
+  /** tick 个数，默认值为 5 */
+  tickCount?: number;
+  /** 计算 ticks 的算法 */
+  tickMethod?: TickMethod<number>;
+  /** 是否需要对定义域的范围进行优化 */
+  nice?: boolean;
+  /** 是否需要限制输入的范围在值域内 */
+  clamp?: boolean;
+  /** 是否需要对输出进行四舍五入 */
+  round?: boolean;
+  /** 插值器的工厂函数，返回一个对归一化后的输入在值域指定范围内插值的函数 */
+  interpolate?: Interpolate<number | string>;
+};
 
 /** Pow 比例尺的选项 */
-export type PowOptions = ContinuousOptions<number> & {
+export type PowOptions = LinearOptions & {
   /** 指数 */
   exponent?: number;
 };
 
 /** Sqrt 比例尺的选项 */
-export type SqrtOptions = Omit<PowOptions, 'exponent'>;
+export type SqrtOptions = LinearOptions;
 
 /** Log 比例尺的选项 */
-export type LogOptions = ContinuousOptions<number> & {
+export type LogOptions = LinearOptions & {
   /** 底数 */
   base?: number;
 };
 
 /** time 比例尺的选项 */
-export type TimeOptions = ContinuousOptions<Date, number> & {
+export type TimeOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: (number | string)[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: Date[];
+  /** tick 个数，默认值为 5 */
+  tickCount?: number;
+  /** 计算 ticks 的算法 */
+  tickMethod?: TickMethod<Date>;
+  /** 是否需要对定义域的范围进行优化 */
+  nice?: boolean;
+  /** 是否需要限制输入的范围在值域内 */
+  clamp?: boolean;
+  /** 是否需要对输出进行四舍五入 */
+  round?: boolean;
+  /** 插值器的工厂函数，返回一个对归一化后的输入在值域指定范围内插值的函数 */
+  interpolate?: Interpolate<number | string>;
   /** getTick 的时间间隔 */
   tickInterval?: number;
   /** 格式化的形式 */
@@ -92,10 +147,25 @@ export type TimeOptions = ContinuousOptions<Date, number> & {
 };
 
 /** OrdinalOptions 比例尺的选项 */
-export type OrdinalOptions = BaseOptions<number | string | Date> & { compare?: Comparator };
+export type OrdinalOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: any[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: any[];
+  /** 比较器 */
+  compare?: Comparator;
+};
 
 /** 详细请参阅 scale/band.ts */
-export type BandOptions = BaseOptions<number | string | Date, number> & {
+export type BandOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: number[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: any[];
   /** 是否取整 */
   round?: boolean;
   /** 内部边距 */
@@ -114,14 +184,41 @@ export type BandOptions = BaseOptions<number | string | Date, number> & {
 export type PointOptions = Omit<BandOptions, 'paddingInner' | 'paddingOuter'>;
 
 /** Threshold 比例尺的选项 */
-export type ThresholdOptions = BaseOptions<number, any>;
+export type ThresholdOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: any[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: number[];
+};
 
 /** Quantize 比例尺的选项 */
-export type QuantizeOptions = ThresholdOptions &
-  TickOptions & {
-    /** 是否需要 nice */
-    nice?: boolean;
-  };
+export type QuantizeOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: any[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: number[];
+  /** 是否需要 nice */
+  nice?: boolean;
+  /** 期望的 tickCount */
+  tickCount?: number;
+  /** 计算 ticks 的算法 */
+  tickMethod?: TickMethod<number>;
+};
 
 /** Quantile 比例尺的选项 */
-export type QuantileOptions = ThresholdOptions & TickOptions;
+export type QuantileOptions = {
+  /** 当需要映射的值不合法的时候，返回的值 */
+  unknown?: any;
+  /** 值域，默认为 [0, 1] */
+  range?: any[];
+  /** 定义域，默认为 [0, 1] */
+  domain?: number[];
+  /** 期望的 tickCount */
+  tickCount?: number;
+  /** 计算 ticks 的算法 */
+  tickMethod?: TickMethod<number>;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,9 @@ export type NiceMethod<T = number> = TickMethod<T>;
 /** 插值器工厂 */
 export type Interpolate<T = number> = (a: T, b: T) => (t: number) => T;
 
+/** 所有支持的插值器工厂 */
+export type Interpolates = Interpolate<number> | Interpolate<string> | Interpolate<number | string>;
+
 /** 比较器 */
 export type Comparator = (a: any, b: any) => number;
 
@@ -81,7 +84,7 @@ export type ContinuousOptions = {
   /** 是否需要对输出进行四舍五入 */
   round?: boolean;
   /** 插值器的工厂函数，返回一个对归一化后的输入在值域指定范围内插值的函数 */
-  interpolate?: Interpolate<number | string>;
+  interpolate?: Interpolates;
 };
 
 /** Linear 比例尺的选项 */
@@ -103,7 +106,7 @@ export type LinearOptions = {
   /** 是否需要对输出进行四舍五入 */
   round?: boolean;
   /** 插值器的工厂函数，返回一个对归一化后的输入在值域指定范围内插值的函数 */
-  interpolate?: Interpolate<number | string>;
+  interpolate?: Interpolates;
 };
 
 /** Pow 比例尺的选项 */
@@ -140,7 +143,7 @@ export type TimeOptions = {
   /** 是否需要对输出进行四舍五入 */
   round?: boolean;
   /** 插值器的工厂函数，返回一个对归一化后的输入在值域指定范围内插值的函数 */
-  interpolate?: Interpolate<number | string>;
+  interpolate?: Interpolates;
   /** getTick 的时间间隔 */
   tickInterval?: number;
   /** 格式化的形式 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,9 @@ export type Interpolate<T = number> = (a: T, b: T) => (t: number) => T;
 /** 比较器 */
 export type Comparator = (a: any, b: any) => number;
 
+/** tickMethod 和 nice 需要使用的参数 */
+export type TickMethodOptions<T = number | Date> = [T, T, number, number?, boolean?];
+
 /** 通用的配置 */
 export type BaseOptions = {
   /** 当需要映射的值不合法的时候，返回的值 */

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,36 @@
+import colorString from 'color-string';
+
+function hue2rgb(p: number, q: number, m: number) {
+  let t = m;
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+}
+
+function hsl2rbg(hsl: number[]) {
+  const h = hsl[0] / 360;
+  const s = hsl[1] / 100;
+  const l = hsl[2] / 100;
+  const a = hsl[3];
+
+  if (s === 0) return [l * 255, l * 255, l * 255, a];
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const r = hue2rgb(p, q, h + 1 / 3);
+  const g = hue2rgb(p, q, h);
+  const b = hue2rgb(p, q, h - 1 / 3);
+  return [r * 255, g * 255, b * 255, a];
+}
+
+export function string2rbg(s: string) {
+  const color = colorString.get(s);
+  if (!color) return null;
+  const { model, value } = color;
+  if (model === 'rgb') return value;
+  if (model === 'hsl') return hsl2rbg(value);
+  return null;
+}

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,4 +1,4 @@
-const colorString = require('color-string');
+import colorString from 'color-string';
 
 function hue2rgb(p: number, q: number, m: number) {
   let t = m;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,4 +1,4 @@
-import colorString from 'color-string';
+const colorString = require('color-string');
 
 function hue2rgb(p: number, q: number, m: number) {
   let t = m;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,5 @@
 export { compose } from './compose';
 export { createNormalize } from './normalize';
-export { createInterpolate, createInterpolateRound } from './interpolate';
 export { createClamp } from './clamp';
 export { bisect } from './bisect';
 export { d3LinearNice } from './d3-linear-nice';
@@ -10,6 +9,12 @@ export { logs, pows } from './log';
 export { d3LogNice } from './d3-log-nice';
 export { tickIncrement, tickStep } from './ticks';
 export { findTickInterval } from './find-tick-interval';
+export {
+  createInterpolateValue,
+  createInterpolateRound,
+  createInterpolateNumber,
+  createInterpolateColor,
+} from './interpolate';
 
 export {
   DURATION_SECOND,

--- a/src/utils/interpolate.ts
+++ b/src/utils/interpolate.ts
@@ -22,8 +22,8 @@ export const createInterpolateColor: Interpolate<string> = (a, b) => {
       const to = c2[i];
       values[i] = from * (1 - t) + to * t;
     }
-    const [r, g, b, a] = values;
-    return `rgba(${r}, ${g}, ${b}, ${a})`;
+    const [r, g, b, a] = values as number[];
+    return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${a})`;
   };
 };
 

--- a/src/utils/interpolate.ts
+++ b/src/utils/interpolate.ts
@@ -1,12 +1,43 @@
 import { Interpolate } from '../types';
+import { string2rbg } from './color';
 
 /**
- * 返回一个线性插值器
+ * 返回一个线性插值器，接受数字
  * @param a 任意值
  * @param b 任意值
  * @returns 线性插值器
  */
-export const createInterpolate: Interpolate = (a, b) => (t) => a * (1 - t) + b * t;
+export const createInterpolateNumber: Interpolate<number> = (a, b) => {
+  return (t) => a * (1 - t) + b * t;
+};
+
+export const createInterpolateColor: Interpolate<string> = (a, b) => {
+  const c1 = string2rbg(a);
+  const c2 = string2rbg(b);
+  if (c1 === null || c2 === null) return c1 ? () => a : () => b;
+  return (t) => {
+    const values = new Array(4);
+    for (let i = 0; i < 4; i += 1) {
+      const from = c1[i];
+      const to = c2[i];
+      values[i] = from * (1 - t) + to * t;
+    }
+    const [r, g, b, a] = values;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+  };
+};
+
+/**
+ * 返回一个线性插值器，接受数字和颜色
+ * @param a 任意值
+ * @param b 任意值
+ * @returns 线性插值器
+ */
+export const createInterpolateValue: Interpolate<number | string> = (a, b) => {
+  if (typeof a === 'number' && typeof b === 'number') return createInterpolateNumber(a, b);
+  if (typeof a === 'string' && typeof b === 'string') return createInterpolateColor(a, b);
+  return () => a;
+};
 
 /**
  * 返回一个 round 线性差值器，对输出值进行四舍五入
@@ -14,4 +45,7 @@ export const createInterpolate: Interpolate = (a, b) => (t) => a * (1 - t) + b *
  * @param b 任意值
  * @returns 线性插值器
  */
-export const createInterpolateRound: Interpolate = (a, b) => (t) => Math.round(createInterpolate(a, b)(t));
+export const createInterpolateRound: Interpolate<number> = (a, b) => {
+  const interpolateNumber = createInterpolateNumber(a, b);
+  return (t) => Math.round(interpolateNumber(t));
+};


### PR DESCRIPTION
- 重构了 types，为了可读性，对于 scale 的 options 没有使用泛型了
- identity 支持 map 任意类型的数据（除了 undefined,nulll, NaN)
- ordinal  的 domain 和 range 都支持 object
- linear 默认使用 interpolateNumber 插值器，但是也暴露了 interpolateColor 和 interpolateValue(interpolateNumber + interpolateColor）这两个插值器给用户选择，具体使用方式见[文档](https://github.com/antvis/scale/blob/feat/types/docs/api/interpolators.md)