### PR TITLE
fix(ticks): tiny number for tickMethods

### DIFF
--- a/src/util/extended.ts
+++ b/src/util/extended.ts
@@ -138,7 +138,6 @@ export default function extended(
           const maxStart = Math.ceil(dMin / step) * j;
 
           if (minStart <= maxStart) {
-            z += 1;
             const count = maxStart - minStart;
             for (let i = 0; i <= count; i += 1) {
               const start = minStart + i;

--- a/src/util/extended.ts
+++ b/src/util/extended.ts
@@ -60,7 +60,7 @@ function legibility() {
 }
 
 // 解决 js 计算精度问题
-function pretty(n: number) {
+function prettyNumber(n: number) {
   return n < 1e-15 ? n : parseFloat(n.toFixed(15));
 }
 
@@ -137,27 +137,27 @@ export default function extended(
           const minStart = Math.floor(dMax / step) * j - (k - 1) * j;
           const maxStart = Math.ceil(dMin / step) * j;
 
-          if (minStart > maxStart) {
+          if (minStart <= maxStart) {
             z += 1;
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-          for (let start = minStart; start <= maxStart; start += 1) {
-            const lMin = start * (step / j);
-            const lMax = lMin + step * (k - 1);
-            const lStep = step;
+            const count = maxStart - minStart;
+            for (let i = 0; i <= count; i += 1) {
+              const start = minStart + i;
+              const lMin = start * (step / j);
+              const lMax = lMin + step * (k - 1);
+              const lStep = step;
 
-            const s = simplicity(q, Q, j, lMin, lMax, lStep);
-            const c = coverage(dMin, dMax, lMin, lMax);
-            const g = density(k, m, dMin, dMax, lMin, lMax);
-            const l = legibility();
+              const s = simplicity(q, Q, j, lMin, lMax, lStep);
+              const c = coverage(dMin, dMax, lMin, lMax);
+              const g = density(k, m, dMin, dMax, lMin, lMax);
+              const l = legibility();
 
-            const score = w[0] * s + w[1] * c + w[2] * g + w[3] * l;
-            if (score > best.score && (!onlyLoose || (lMin <= dMin && lMax >= dMax))) {
-              best.lmin = lMin;
-              best.lmax = lMax;
-              best.lstep = lStep;
-              best.score = score;
+              const score = w[0] * s + w[1] * c + w[2] * g + w[3] * l;
+              if (score > best.score && (!onlyLoose || (lMin <= dMin && lMax >= dMax))) {
+                best.lmin = lMin;
+                best.lmax = lMax;
+                best.lstep = lStep;
+                best.score = score;
+              }
             }
           }
           z += 1;
@@ -168,15 +168,13 @@ export default function extended(
     j += 1;
   }
 
-  const size = Math.floor((best.lmax - best.lmin) / best.lstep);
-  const ticks = new Array(size);
-  let i = 0;
-
-  for (let tick = best.lmin; tick <= best.lmax; tick += best.lstep) {
-    ticks[i] = pretty(tick);
-    i += 1;
+  const { lmax, lmin, lstep } = best;
+  const tickCount = Math.floor((lmax - lmin) / lstep) + 1;
+  const ticks = new Array(tickCount);
+  for (let i = 0; i < tickCount; i++) {
+    ticks[i] = prettyNumber(lmin + i * lstep);
   }
-  
+
   return {
     min: Math.min(dMin, head(ticks)),
     max: Math.max(dMax, last(ticks)),

--- a/src/util/pretty.ts
+++ b/src/util/pretty.ts
@@ -1,11 +1,8 @@
+function prettyNumber(n: number) {
+  return n < 1e-15 ? n : parseFloat(n.toFixed(15));
+}
+
 export default function pretty(min: number, max: number, n: number = 5) {
-
-  const res = {
-    max: 0,
-    min: 0,
-    ticks: [],
-  };
-
   if (min === max) {
     return {
       max,
@@ -32,7 +29,6 @@ export default function pretty(min: number, max: number, n: number = 5) {
   // }
 
   const base = Math.pow(10, Math.floor(Math.log10(c)));
-  const toFixed = base < 1 ? Math.ceil(Math.abs(Math.log10(base))) : 0;
   let unit = base;
   if (2 * base - c < h * (c - unit)) {
     unit = 2 * base;
@@ -46,18 +42,18 @@ export default function pretty(min: number, max: number, n: number = 5) {
   const nu = Math.ceil(max / unit);
   const ns = Math.floor(min / unit);
 
-  res.max = Math.max(nu * unit, max);
-  res.min = Math.min(ns * unit, min);
+  const hi = Math.max(nu * unit, max);
+  const lo = Math.min(ns * unit, min);
 
-  let x = Number.parseFloat((ns * unit).toFixed(toFixed));
-  while (x < max) {
-    res.ticks.push(x);
-    x += unit;
-    if (toFixed) {
-      x = Number.parseFloat(x.toFixed(toFixed));
-    }
+  const size = Math.floor((hi - lo) / unit) + 1;
+  const ticks = new Array(size);
+  for (let i = 0; i < size; i++) {
+    ticks[i] = prettyNumber(lo + i * unit);
   }
-  res.ticks.push(x);
 
-  return res;
+  return {
+    min: lo,
+    max: hi,
+    ticks,
+  };
 }

--- a/tests/unit/linear-spec.ts
+++ b/tests/unit/linear-spec.ts
@@ -11,7 +11,7 @@ describe('linear scale', () => {
     },
   });
 
-  it('type', function() {
+  it('type', function () {
     expect(scale.type).toEqual('linear');
     expect(scale.isLinear).toBeTruthy();
   });
@@ -195,14 +195,12 @@ describe('linear with minLimit & maxLimit', () => {
   expect(last(scale.ticks)).toBe(0.96);
 });
 
-// interval, minTickInterval 当前 ticks 的计算方法都不支持
-describe.skip('linear scale with Interval', () => {
-  it('c(0, 62), minInterval = 14', () => {
+describe('linear ticks', () => {
+  it('handle tiny numbers', () => {
     const scale = new Linear({
-      min: 0,
-      max: 62,
-      minTickInterval: 14,
+      min: 9.899999999999999,
+      max: 9.9,
     });
-    expect(scale.ticks).toEqual([0, 14, 28, 42, 56, 70]);
+    expect(scale.ticks).toEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
 });

--- a/tests/unit/util/extended-spec.ts
+++ b/tests/unit/util/extended-spec.ts
@@ -52,7 +52,7 @@ describe('extended ticks', function () {
   it('extended for c(0.243, 0.584, 0.987, 0.153, 0.433)', () => {
     const scale1 = extended(0.153, 0.987);
     // d3 version == [0.2, 0.4, 0.6000000000000001, 0.8, 1]
-    expect(scale1.ticks).toEqual([ 0, 0.25, 0.5, 0.75, 1 ]);
+    expect(scale1.ticks).toEqual([0, 0.25, 0.5, 0.75, 1]);
     const scale2 = extended(0.153, 0.987, 10);
     // same as d3
     expect(scale2.ticks).toEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
@@ -75,11 +75,10 @@ describe('extended ticks', function () {
     expect(extended(0, 0.01, 5).ticks).toStrictEqual([0, 0.0025, 0.005, 0.0075, 0.01]);
     expect(extended(0, 0.001, 5).ticks).toStrictEqual([0, 0.00025, 0.0005, 0.00075, 0.001]);
     expect(extended(0, 0.0001, 6).ticks).toStrictEqual([0, 0.00002, 0.00004, 0.00006, 0.00008, 0.0001, 0.00012]);
-    expect(extended(0, 0.00001, 6).ticks).toStrictEqual([
-      0, 0.000002, 0.000004, 0.000006, 0.000008, 0.00001, 0.000012,
-    ]);
+    expect(extended(0, 0.00001, 6).ticks).toStrictEqual([0, 0.000002, 0.000004, 0.000006, 0.000008, 0.00001, 0.000012]);
     expect(extended(0, 0.000001, 6).ticks).toStrictEqual([0, 0.0000002, 0.0000004, 0.0000006, 0.0000008, 0.000001]);
     expect(extended(0, 1e-15, 6).ticks).toStrictEqual([0, 2e-16, 4e-16, 6e-16, 8e-16, 1e-15]);
+    expect(extended(9.899999999999999, 9.9).ticks).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
 
   it('precision', () => {

--- a/tests/unit/util/pretty-spec.ts
+++ b/tests/unit/util/pretty-spec.ts
@@ -1,6 +1,6 @@
 import pretty from '../../../src/util/pretty';
 
-describe('pretty ticks', function() {
+describe('pretty ticks', function () {
   it('pretty for c(0, 0)', () => {
     const res = pretty(0, 0);
     expect(res.ticks).toEqual([0]);
@@ -8,71 +8,65 @@ describe('pretty ticks', function() {
 
   it('pretty for c(0, 10)', () => {
     const res = pretty(0, 10);
-    expect(res.ticks).toEqual([ 0, 2, 4, 6, 8, 10 ]);
+    expect(res.ticks).toEqual([0, 2, 4, 6, 8, 10]);
   });
 
   it('pretty for c(1, 9.5)', () => {
     const res = pretty(1, 9.5);
-    expect(res.ticks).toEqual([ 0, 2, 4, 6, 8, 10 ]);
+    expect(res.ticks).toEqual([0, 2, 4, 6, 8, 10]);
   });
 
   it('pretty for c(1, 11)', () => {
     const res = pretty(1, 11);
-    expect(res.ticks).toEqual([ 0, 2, 4, 6, 8, 10, 12 ]);
+    expect(res.ticks).toEqual([0, 2, 4, 6, 8, 10, 12]);
   });
 
   it('pretty for c(3, 97)', () => {
     const res = pretty(3, 97);
-    expect(res.ticks).toEqual([ 0, 20, 40, 60, 80, 100 ]);
+    expect(res.ticks).toEqual([0, 20, 40, 60, 80, 100]);
   });
 
   it('pretty for c(-100, -10)', () => {
     const res = pretty(-100, -10);
-    expect(res.ticks).toEqual([ -100, -80, -60, -40, -20, 0 ]);
+    expect(res.ticks).toEqual([-100, -80, -60, -40, -20, 0]);
   });
 
   it('pretty for c(0, 4200)', () => {
     const res = pretty(0, 4200);
     // g2 3.0 = [ 0, 1200, 2400, 3600, 4800 ]
-    expect(res.ticks).toEqual([ 0, 1000, 2000, 3000, 4000, 5000 ]);
+    expect(res.ticks).toEqual([0, 1000, 2000, 3000, 4000, 5000]);
   });
 
   it('pretty for c(0.0002, 0.001)', () => {
     const res = pretty(0.0002, 0.001);
-    expect(res.ticks).toEqual([ 0.0002, 0.0004, 0.0006, 0.0008, 0.001 ]);
+    expect(res.ticks).toEqual([0.0002, 0.0004, 0.0006, 0.0008, 0.001, 0.0012]);
   });
 
   it('pretty for c(-5, 605)', () => {
     const res = pretty(-5, 605, 5);
-    expect(res.ticks).toEqual([ -100, 0, 100, 200, 300, 400, 500, 600, 700 ]);
+    expect(res.ticks).toEqual([-100, 0, 100, 200, 300, 400, 500, 600, 700]);
   });
 
   it('pretty for c(0, 0.0000267519)', () => {
     const res = pretty(0, 0.0000267519);
-    expect(res.ticks).toEqual([ 0, 0.000005, 0.00001, 0.000015, 0.00002, 0.000025, 0.00003 ]);
+    expect(res.ticks).toEqual([0, 0.000005, 0.00001, 0.000015, 0.00002, 0.000025, 0.00003]);
   });
 
   it('pretty for c(0.0000237464, 0.0000586372)', () => {
     const res = pretty(0.0000237464, 0.0000586372);
-    expect(res.ticks).toEqual([
-      0.00002,
-      0.000025,
-      0.00003,
-      0.000035,
-      0.00004,
-      0.000045,
-      0.00005,
-      0.000055,
-      0.00006,
-    ]);
+    expect(res.ticks).toEqual([0.00002, 0.000025, 0.00003, 0.000035, 0.00004, 0.000045, 0.00005, 0.000055, 0.00006]);
   });
 
   it('pretty for c(0.243, 0.584, 0.987, 0.153, 0.433)', () => {
     const scale1 = pretty(0.153, 0.987);
     // d3 version == [0.2, 0.4, 0.6000000000000001, 0.8, 1]
-    expect(scale1.ticks).toEqual([ 0, 0.2, 0.4, 0.6, 0.8, 1 ]);
+    expect(scale1.ticks).toEqual([0, 0.2, 0.4, 0.6, 0.8, 1]);
     const scale2 = pretty(0.153, 0.987, 10);
     // same as d3
-    expect(scale2.ticks).toEqual([ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1 ]);
+    expect(scale2.ticks).toEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
+  });
+
+  it('pretty for tiny number', () => {
+    expect(pretty(9.899999999999999, 9.9).ticks).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
 });


### PR DESCRIPTION
修复了下面出现死循环的问题：

```js
extended(9.899999999999999, 9.9)
pretty(9.899999999999999, 9.9)
```

出现原因是精度问题：
```js
const start = 9.899999999999999;
const end = 9.9;
const step = 5e-15;
for(let i = start; i < end; i += step) {} // 死循环 i += step 始终等于 9.899999999999999
```
```js
const start = 19799999999999996;
const end = 19799999999999996;
const step = 1;
for(let i = start; i <= end; i += step) {} // 死循环 i += step 始终等于 19799999999999996
```

解决办法
```js
const start = 9.899999999999999;
const end = 9.9;
const step = 5e-15;
const count = Math.floor((start - end) / step);
for(let i = 0; i < count; i += 1) {}
```