### PR TITLE
fix(ticks): tickMethods for tiny numbers

### DIFF
--- a/__tests__/unit/tick-methods/r-pretty.spec.ts
+++ b/__tests__/unit/tick-methods/r-pretty.spec.ts
@@ -39,7 +39,7 @@ describe('rPretty ticks', () => {
 
   it('rPretty for c(0.0002, 0.001)', () => {
     const res = rPretty(0.0002, 0.001);
-    expect(res).toEqual([0.0002, 0.0004, 0.0006, 0.0008, 0.001]);
+    expect(res).toEqual([0.0002, 0.0004, 0.0006, 0.0008, 0.001, 0.0012]);
   });
 
   it('rPretty for c(-5, 605)', () => {
@@ -64,5 +64,9 @@ describe('rPretty ticks', () => {
     const scale2 = rPretty(0.153, 0.987, 10);
     // same as d3
     expect(scale2).toEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
+  });
+
+  it('rPretty for tiny number', () => {
+    expect(rPretty(9.899999999999999, 9.9)).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
 });

--- a/__tests__/unit/tick-methods/wilkinson-extended.spec.ts
+++ b/__tests__/unit/tick-methods/wilkinson-extended.spec.ts
@@ -35,6 +35,7 @@ describe('wilkinson-extended test', () => {
     ]);
     expect(wilkinsonExtended(0, 0.000001, 6)).toStrictEqual([0, 0.0000002, 0.0000004, 0.0000006, 0.0000008, 0.000001]);
     expect(wilkinsonExtended(0, 1e-15, 6)).toStrictEqual([0, 2e-16, 4e-16, 6e-16, 8e-16, 1e-15]);
+    expect(wilkinsonExtended(9.899999999999999, 9.9)).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
 
   test('precision', () => {

--- a/__tests__/unit/utils/pretty-number.spec.ts
+++ b/__tests__/unit/utils/pretty-number.spec.ts
@@ -1,0 +1,8 @@
+import { prettyNumber } from '../../../src/utils/pretty-number';
+
+describe('prettyNumber', () => {
+  test('prettyNumber number', () => {
+    expect(prettyNumber(1e-16)).toBe(1e-16);
+    expect(prettyNumber(0.1 + 0.2)).toBe(0.3);
+  });
+});

--- a/src/tick-methods/r-pretty.ts
+++ b/src/tick-methods/r-pretty.ts
@@ -1,4 +1,5 @@
 import { TickMethod } from '../types';
+import { prettyNumber } from '../utils/pretty-number';
 
 /**
  * 创建分割点
@@ -10,12 +11,6 @@ import { TickMethod } from '../types';
  * @see R pretty https://www.rdocumentation.org/packages/base/versions/3.5.2/topics/pretty
  */
 export const rPretty: TickMethod = (min, max, n = 5) => {
-  const res = {
-    max: 0,
-    min: 0,
-    ticks: [],
-  };
-
   if (min === max) {
     return [min];
   }
@@ -36,7 +31,6 @@ export const rPretty: TickMethod = (min, max, n = 5) => {
   // }
 
   const base = 10 ** Math.floor(Math.log10(c));
-  const toFixed = base < 1 ? Math.ceil(Math.abs(Math.log10(base))) : 0;
   let unit = base;
   if (2 * base - c < h * (c - unit)) {
     unit = 2 * base;
@@ -50,18 +44,14 @@ export const rPretty: TickMethod = (min, max, n = 5) => {
   const nu = Math.ceil(max / unit);
   const ns = Math.floor(min / unit);
 
-  res.max = Math.max(nu * unit, max);
-  res.min = Math.min(ns * unit, min);
+  const hi = Math.max(nu * unit, max);
+  const lo = Math.min(ns * unit, min);
 
-  let x = Number.parseFloat((ns * unit).toFixed(toFixed));
-  while (x < max) {
-    res.ticks.push(x);
-    x += unit;
-    if (toFixed) {
-      x = Number.parseFloat(x.toFixed(toFixed));
-    }
+  const size = Math.floor((hi - lo) / unit) + 1;
+  const ticks = new Array(size);
+  for (let i = 0; i < size; i += 1) {
+    ticks[i] = prettyNumber(lo + i * unit);
   }
-  res.ticks.push(x);
 
-  return res.ticks;
+  return ticks;
 };

--- a/src/utils/pretty-number.ts
+++ b/src/utils/pretty-number.ts
@@ -1,0 +1,4 @@
+// 为了解决 js 运算的精度问题
+export function prettyNumber(n: number) {
+  return n < 1e-15 ? n : parseFloat(n.toFixed(15));
+}


### PR DESCRIPTION
修复了下面出现死循环的问题：

```js
extended(9.899999999999999, 9.9)
pretty(9.899999999999999, 9.9)
```

出现原因是精度问题：
```js
const start = 9.899999999999999;
const end = 9.9;
const step = 5e-15;
for(let i = start; i < end; i += step) {} // 死循环 i += step 始终等于 9.899999999999999
```
```js
const start = 19799999999999996;
const end = 19799999999999996;
const step = 1;
for(let i = start; i <= end; i += step) {} // 死循环 i += step 始终等于 19799999999999996
```

解决办法
```js
const start = 9.899999999999999;
const end = 9.9;
const step = 5e-15;
const count = Math.floor((start - end) / step);
for(let i = 0; i < count; i += 1) {}
```