### PR TITLE
fix(ticks): handle decimal and negative tick count

### DIFF
--- a/src/util/extended.ts
+++ b/src/util/extended.ts
@@ -77,11 +77,14 @@ function prettyNumber(n: number) {
 export default function extended(
   dMin: number,
   dMax: number,
-  m: number = 5,
+  n: number = 5,
   onlyLoose: boolean = true,
   Q: number[] = DEFAULT_Q,
   w: [number, number, number, number] = [0.25, 0.2, 0.5, 0.05]
 ): { min: number; max: number; ticks: number[] } {
+  // 处理小于 0 和小数的 tickCount
+  const m = n < 0 ? 0 : Math.round(n);
+
   // nan 也会导致异常
   if (Number.isNaN(dMin) || Number.isNaN(dMax) || typeof dMin !== 'number' || typeof dMax !== 'number' || !m) {
     return {

--- a/src/util/pretty.ts
+++ b/src/util/pretty.ts
@@ -2,7 +2,7 @@ function prettyNumber(n: number) {
   return n < 1e-15 ? n : parseFloat(n.toFixed(15));
 }
 
-export default function pretty(min: number, max: number, n: number = 5) {
+export default function pretty(min: number, max: number, m: number = 5) {
   if (min === max) {
     return {
       max,
@@ -10,6 +10,9 @@ export default function pretty(min: number, max: number, n: number = 5) {
       ticks: [min],
     };
   }
+
+  const n = m < 0 ? 0 : Math.round(m);
+  if (n === 0) return { max, min, ticks: [] };
 
   /*
     R pretty:

--- a/tests/unit/util/extended-spec.ts
+++ b/tests/unit/util/extended-spec.ts
@@ -84,4 +84,14 @@ describe('extended ticks', function () {
   it('precision', () => {
     expect(extended(0, 1.2, 5).ticks).toStrictEqual([0, 0.3, 0.6, 0.9, 1.2]);
   });
+
+  it('handle decimal tickCount', () => {
+    expect(extended(0, 5, 0.4).ticks).toStrictEqual(extended(0, 5, 0).ticks);
+    expect(extended(0, 5, 0.5).ticks).toStrictEqual(extended(0, 5, 1).ticks);
+  });
+
+  it('handle negative tickCount', () => {
+    expect(extended(0, 5, -1).ticks).toStrictEqual(extended(0, 5, 0).ticks);
+    expect(extended(0, 5, -1.2).ticks).toStrictEqual(extended(0, 5, 0).ticks);
+  });
 });

--- a/tests/unit/util/pretty-spec.ts
+++ b/tests/unit/util/pretty-spec.ts
@@ -69,4 +69,15 @@ describe('pretty ticks', function () {
   it('pretty for tiny number', () => {
     expect(pretty(9.899999999999999, 9.9).ticks).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
+
+
+  it('handle decimal tickCount', () => {
+    expect(pretty(0, 5, 0.4).ticks).toStrictEqual(pretty(0, 5, 0).ticks);
+    expect(pretty(0, 5, 0.5).ticks).toStrictEqual(pretty(0, 5, 1).ticks);
+  });
+
+  it('handle negative tickCount', () => {
+    expect(pretty(0, 5, -1).ticks).toStrictEqual(pretty(0, 5, 0).ticks);
+    expect(pretty(0, 5, -1.2).ticks).toStrictEqual(pretty(0, 5, 0).ticks);
+  });
 });


### PR DESCRIPTION
处理 tickCount 为小数和负数的情况，处理办法如下

```js
const n = m < 0 ? 0 : Math.round(m);
if (n === 0) return [];
```