### PR TITLE
fix(ticks): handle decimal and negative tickCount

### DIFF
--- a/__tests__/unit/tick-methods/d3-ticks.spec.ts
+++ b/__tests__/unit/tick-methods/d3-ticks.spec.ts
@@ -1,6 +1,6 @@
 import { d3Ticks as fn } from '../../../src';
 
-describe('linear ticks', () => {
+describe('d3 ticks', () => {
   test('common usage', () => {
     expect(fn(0, 1000, 10)).toStrictEqual([0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]);
 
@@ -18,5 +18,15 @@ describe('linear ticks', () => {
 
   test('reverse data', () => {
     expect(fn(0.1, 0.8, 5)).toStrictEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]);
+  });
+
+  test('handle decimal tickCount', () => {
+    expect(fn(0, 5, 0.4)).toStrictEqual([0]);
+    expect(fn(0, 5, 1.5)).toStrictEqual([0, 5]);
+  });
+
+  test('handle negative tickCount', () => {
+    expect(fn(0, 5, -1)).toStrictEqual(fn(0, 5, 0));
+    expect(fn(0, 5, -1.2)).toStrictEqual(fn(0, 5, 0));
   });
 });

--- a/__tests__/unit/tick-methods/r-pretty.spec.ts
+++ b/__tests__/unit/tick-methods/r-pretty.spec.ts
@@ -69,4 +69,14 @@ describe('rPretty ticks', () => {
   it('rPretty for tiny number', () => {
     expect(rPretty(9.899999999999999, 9.9)).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
+
+  it('handle decimal tickCount', () => {
+    expect(rPretty(0, 5, 0.4)).toStrictEqual(rPretty(0, 5, 0));
+    expect(rPretty(0, 5, 0.5)).toStrictEqual(rPretty(0, 5, 1));
+  });
+
+  it('handle negative tickCount', () => {
+    expect(rPretty(0, 5, -1)).toStrictEqual(rPretty(0, 5, 0));
+    expect(rPretty(0, 5, -1.2)).toStrictEqual(rPretty(0, 5, 0));
+  });
 });

--- a/__tests__/unit/tick-methods/wilkinson-extended.spec.ts
+++ b/__tests__/unit/tick-methods/wilkinson-extended.spec.ts
@@ -41,4 +41,14 @@ describe('wilkinson-extended test', () => {
   test('precision', () => {
     expect(wilkinsonExtended(0, 1.2, 5)).toStrictEqual([0, 0.3, 0.6, 0.9, 1.2]);
   });
+
+  test('handle decimal tickCount', () => {
+    expect(wilkinsonExtended(0, 5, 0.4)).toStrictEqual(wilkinsonExtended(0, 5, 0));
+    expect(wilkinsonExtended(0, 5, 0.5)).toStrictEqual(wilkinsonExtended(0, 5, 1));
+  });
+
+  test('handle negative tickCount', () => {
+    expect(wilkinsonExtended(0, 5, -1)).toStrictEqual(wilkinsonExtended(0, 5, 0));
+    expect(wilkinsonExtended(0, 5, -1.2)).toStrictEqual(wilkinsonExtended(0, 5, 0));
+  });
 });

--- a/src/tick-methods/r-pretty.ts
+++ b/src/tick-methods/r-pretty.ts
@@ -10,10 +10,13 @@ import { prettyNumber } from '../utils/pretty-number';
  * @see R pretty https://svn.r-project.org/R/trunk/src/appl/pretty.c
  * @see R pretty https://www.rdocumentation.org/packages/base/versions/3.5.2/topics/pretty
  */
-export const rPretty: TickMethod = (min, max, n = 5) => {
+export const rPretty: TickMethod = (min, max, m = 5) => {
   if (min === max) {
     return [min];
   }
+
+  const n = m < 0 ? 0 : Math.round(m);
+  if (n === 0) return [];
 
   // high.u.bias
   const h = 1.5;

--- a/src/tick-methods/wilkinson-extended.ts
+++ b/src/tick-methods/wilkinson-extended.ts
@@ -74,11 +74,12 @@ function legibility() {
 export const wilkinsonExtended: TickMethod = (
   dMin: number,
   dMax: number,
-  m: number = 5,
+  n: number = 5,
   onlyLoose: boolean = true,
   Q: number[] = DEFAULT_Q,
   w: [number, number, number, number] = [0.25, 0.2, 0.5, 0.05]
 ) => {
+  const m = n < 0 ? 0 : Math.round(n);
   // nan 也会导致异常
   if (Number.isNaN(dMin) || Number.isNaN(dMax) || typeof dMin !== 'number' || typeof dMax !== 'number' || !m) {
     return [];


### PR DESCRIPTION
处理 tickCount 为小数和负数的情况，处理办法如下

```js
const n = m < 0 ? 0 : Math.round(m);
if (n === 0) return [];
```