### PR TITLE
fix(ticks): pretty negative number

### DIFF
--- a/src/util/extended.ts
+++ b/src/util/extended.ts
@@ -1,4 +1,5 @@
 import { head, indexOf, size, last } from '@antv/util';
+import { prettyNumber } from './pretty-number';
 
 export const DEFAULT_Q = [1, 5, 2, 2.5, 4, 3];
 
@@ -57,11 +58,6 @@ function coverageMax(dMin: number, dMax: number, span: number) {
 
 function legibility() {
   return 1;
-}
-
-// 解决 js 计算精度问题
-function prettyNumber(n: number) {
-  return n < 1e-15 ? n : parseFloat(n.toFixed(15));
 }
 
 /**

--- a/src/util/pretty-number.ts
+++ b/src/util/pretty-number.ts
@@ -1,0 +1,4 @@
+// 为了解决 js 运算的精度问题
+export function prettyNumber(n: number) {
+  return Math.abs(n) < 1e-15 ? n : parseFloat(n.toFixed(15));
+}

--- a/src/util/pretty.ts
+++ b/src/util/pretty.ts
@@ -1,6 +1,4 @@
-function prettyNumber(n: number) {
-  return n < 1e-15 ? n : parseFloat(n.toFixed(15));
-}
+import { prettyNumber } from './pretty-number';
 
 export default function pretty(min: number, max: number, m: number = 5) {
   if (min === max) {

--- a/tests/unit/util/extended-spec.ts
+++ b/tests/unit/util/extended-spec.ts
@@ -94,4 +94,8 @@ describe('extended ticks', function () {
     expect(extended(0, 5, -1).ticks).toStrictEqual(extended(0, 5, 0).ticks);
     expect(extended(0, 5, -1.2).ticks).toStrictEqual(extended(0, 5, 0).ticks);
   });
+
+  it('handle negative tickValue', () => {
+    expect(extended(-0.4, 0).ticks).toStrictEqual([-0.4, -0.3, -0.2, -0.1, 0])
+  })
 });

--- a/tests/unit/util/pretty-number-spec.ts
+++ b/tests/unit/util/pretty-number-spec.ts
@@ -1,0 +1,12 @@
+import { prettyNumber } from '../../../src/util/pretty-number';
+
+describe('prettyNumber', () => {
+  test('prettyNumber number', () => {
+    expect(prettyNumber(1e-16)).toBe(1e-16);
+    expect(prettyNumber(0.09999999999999998)).toBe(0.1);
+    expect(prettyNumber(0.1 + 0.2)).toBe(0.3);
+    expect(prettyNumber(-1e-16)).toBe(-1e-16);
+    expect(prettyNumber(-0.09999999999999998)).toBe(-0.1);
+    expect(prettyNumber(-(0.1 + 0.2))).toBe(-0.3);
+  });
+});

--- a/tests/unit/util/pretty-spec.ts
+++ b/tests/unit/util/pretty-spec.ts
@@ -70,7 +70,6 @@ describe('pretty ticks', function () {
     expect(pretty(9.899999999999999, 9.9).ticks).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
   });
 
-
   it('handle decimal tickCount', () => {
     expect(pretty(0, 5, 0.4).ticks).toStrictEqual(pretty(0, 5, 0).ticks);
     expect(pretty(0, 5, 0.5).ticks).toStrictEqual(pretty(0, 5, 1).ticks);
@@ -79,5 +78,9 @@ describe('pretty ticks', function () {
   it('handle negative tickCount', () => {
     expect(pretty(0, 5, -1).ticks).toStrictEqual(pretty(0, 5, 0).ticks);
     expect(pretty(0, 5, -1.2).ticks).toStrictEqual(pretty(0, 5, 0).ticks);
+  });
+
+  it('handle negative tickValue', () => {
+    expect(pretty(-0.4, 0).ticks).toStrictEqual([-0.4, -0.3, -0.2, -0.1, 0]);
   });
 });


### PR DESCRIPTION
修复当 tick 的 range 是负数时候的情况。

```js
// before fix
extended(-0.4, 0) // [-0.4, -0.30000000000000004, -0.2, -0.09999999999999998, 0]

// after fix
extended(-0.4, 0) // [-0.4, -0.3, -0.2, -0.1, 0]
```