### PR TITLE
fix(ticks): pretty negative ticks

### DIFF
--- a/__tests__/unit/tick-methods/r-pretty.spec.ts
+++ b/__tests__/unit/tick-methods/r-pretty.spec.ts
@@ -79,4 +79,8 @@ describe('rPretty ticks', () => {
     expect(rPretty(0, 5, -1)).toStrictEqual(rPretty(0, 5, 0));
     expect(rPretty(0, 5, -1.2)).toStrictEqual(rPretty(0, 5, 0));
   });
+
+  it('handle negative tickValue', () => {
+    expect(rPretty(-0.4, 0)).toStrictEqual([-0.4, -0.3, -0.2, -0.1, 0]);
+  });
 });

--- a/__tests__/unit/tick-methods/wilkinson-extended.spec.ts
+++ b/__tests__/unit/tick-methods/wilkinson-extended.spec.ts
@@ -51,4 +51,8 @@ describe('wilkinson-extended test', () => {
     expect(wilkinsonExtended(0, 5, -1)).toStrictEqual(wilkinsonExtended(0, 5, 0));
     expect(wilkinsonExtended(0, 5, -1.2)).toStrictEqual(wilkinsonExtended(0, 5, 0));
   });
+
+  test('handle negative tickValue', () => {
+    expect(wilkinsonExtended(-0.4, 0)).toStrictEqual([-0.4, -0.3, -0.2, -0.1, 0]);
+  });
 });

--- a/__tests__/unit/utils/pretty-number.spec.ts
+++ b/__tests__/unit/utils/pretty-number.spec.ts
@@ -3,6 +3,10 @@ import { prettyNumber } from '../../../src/utils/pretty-number';
 describe('prettyNumber', () => {
   test('prettyNumber number', () => {
     expect(prettyNumber(1e-16)).toBe(1e-16);
+    expect(prettyNumber(0.09999999999999998)).toBe(0.1);
     expect(prettyNumber(0.1 + 0.2)).toBe(0.3);
+    expect(prettyNumber(-1e-16)).toBe(-1e-16);
+    expect(prettyNumber(-0.09999999999999998)).toBe(-0.1);
+    expect(prettyNumber(-(0.1 + 0.2))).toBe(-0.3);
   });
 });

--- a/src/utils/pretty-number.ts
+++ b/src/utils/pretty-number.ts
@@ -1,4 +1,4 @@
 // 为了解决 js 运算的精度问题
 export function prettyNumber(n: number) {
-  return n < 1e-15 ? n : parseFloat(n.toFixed(15));
+  return Math.abs(n) < 1e-15 ? n : parseFloat(n.toFixed(15));
 }


### PR DESCRIPTION
修复当 tick 的 range 是负数时候的情况。

```js
// before fix
extended(-0.4, 0) // [-0.4, -0.30000000000000004, -0.2, -0.09999999999999998, 0]

// after fix
extended(-0.4, 0) // [-0.4, -0.3, -0.2, -0.1, 0]
```