### PR TITLE
fix(band): using normalizedFlex to compute bandWidth and step

### DIFF
--- a/__tests__/unit/scales/band.spec.ts
+++ b/__tests__/unit/scales/band.spec.ts
@@ -182,6 +182,27 @@ describe('band scale', () => {
     expect(bandScale.map('C')).toBeCloseTo(416.67);
   });
 
+  test('test non-normalized flex options', () => {
+    const bandScale = new Band({
+      domain: ['A', 'B', 'C'],
+      flex: [20, 30, 10],
+      range: [0, 500],
+    });
+
+    const ba = bandScale.getBandWidth('A');
+    const bb = bandScale.getBandWidth('B');
+    const bc = bandScale.getBandWidth('C');
+    expect([ba, bb, bc].map((d) => d / bc)).toEqual([2, 3, 1]);
+
+    expect(bandScale.getStep('A')).toBeCloseTo(166.67);
+    expect(bandScale.getStep('B')).toBe(250);
+    expect(bandScale.getStep('C')).toBeCloseTo(83.33);
+
+    expect(bandScale.map('A')).toBe(0);
+    expect(bandScale.map('B')).toBeCloseTo(166.67);
+    expect(bandScale.map('C')).toBeCloseTo(416.67);
+  });
+
   test('test patch flex options', () => {
     const bandScale = new Band({
       domain: ['A', 'B', 'C'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/scale",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Toolkit for mapping abstract data into visual representation.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/scales/band.ts
+++ b/src/scales/band.ts
@@ -76,13 +76,13 @@ function computeBandState(options: BandStateOptions) {
   // 计算每个 bandWidth 和 step，并且用定义域内的值索引
   const valueBandWidth = new Map(
     domain.map((d, i) => {
-      const bandWidth = flex[i] * minBandWidth;
+      const bandWidth = normalizedFlex[i] * minBandWidth;
       return [d, round ? Math.floor(bandWidth) : bandWidth];
     })
   );
   const valueStep = new Map(
     domain.map((d, i) => {
-      const bandWidth = flex[i] * minBandWidth;
+      const bandWidth = normalizedFlex[i] * minBandWidth;
       const step = bandWidth + PI;
       return [d, round ? Math.floor(step) : step];
     })


### PR DESCRIPTION
Below band scale will compute wrong bandWidth and step because the flex options is not normalized. This PR fix this problem.

```js
const band = new Band({
  flex: [100, 200, 300]
});
```