### PR TITLE
feat: add sequential scale (close #188)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,9 @@ module.exports = {
   rules: {
     semi: 'error',
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error'],
+    '@typescript-eslint/no-unused-vars': ['off'],
+    'no-redeclare': 'off',
+    '@typescript-eslint/no-redeclare': ['error'],
     'import/extensions': 'off',
     'import/prefer-default-export': 'off',
     'object-curly-newline': 'off',
@@ -25,6 +27,8 @@ module.exports = {
     'arrow-body-style': 'off',
     'no-useless-constructor': 'off',
     'no-nested-ternary': 'off',
+    'no-param-reassign': 'off',
+    'func-names': ['error', 'never'],
   },
   settings: {
     'import/parsers': {

--- a/__tests__/unit/scales/sequential.spec.ts
+++ b/__tests__/unit/scales/sequential.spec.ts
@@ -1,0 +1,100 @@
+import { identity } from '@antv/util';
+import { Sequential } from '../../../src';
+import { d3Ticks } from '../../../src/tick-methods/d3-ticks';
+
+describe('Sequential Scale Test', () => {
+  test('test default options', () => {
+    const scale = new Sequential();
+    const { domain, interpolator, range, round, tickCount, nice, clamp, unknown, tickMethod } = scale.getOptions();
+
+    expect(domain).toStrictEqual([0, 1]);
+    expect(interpolator).toStrictEqual(identity);
+    expect(range).toStrictEqual([0, 1]);
+    expect(round).toBeFalsy();
+    expect(tickCount).toStrictEqual(5);
+    expect(nice).toBeFalsy();
+    expect(clamp).toBeFalsy();
+    expect(unknown).toBeUndefined();
+    expect(tickMethod).toBe(d3Ticks);
+  });
+
+  test('test interpolator fn', () => {
+    const scale = new Sequential({
+      domain: [0, 10],
+      interpolator: (t) => 1 - t,
+    });
+    expect(scale.map(5)).toStrictEqual(0.5);
+    expect(scale.map(2)).toStrictEqual(0.8);
+    expect(scale.map(8)).toStrictEqual(0.19999999999999996);
+    expect(scale.getOptions().range).toStrictEqual([1, 0]);
+
+    scale.update({
+      domain: [10, 0],
+    });
+    expect(scale.map(2)).toStrictEqual(0.19999999999999996);
+    expect(scale.map(8)).toStrictEqual(0.8);
+    expect(scale.getOptions().range).toStrictEqual([1, 0]);
+
+    scale.update({
+      domain: [5, 5],
+    });
+    expect(scale.map(5)).toStrictEqual(0.5);
+    expect(scale.map(2)).toStrictEqual(0.5);
+    expect(scale.map(8)).toStrictEqual(0.5);
+    expect(scale.getOptions().range).toStrictEqual([1, 0]);
+  });
+
+  test('test round the output', () => {
+    const scale = new Sequential({
+      domain: [0, 10],
+      interpolator: (t) => 2 * t + 1,
+      round: true,
+    });
+    expect(scale.map(5)).toStrictEqual(2);
+    expect(scale.map(2)).toStrictEqual(1);
+    expect(scale.map(8)).toStrictEqual(3);
+    expect(scale.getOptions().range).toStrictEqual([1, 3]);
+
+    scale.update({
+      interpolator: (t) => `test: ${2 * t + 1}`,
+    });
+    expect(scale.map(5)).toStrictEqual('test: 2');
+    expect(scale.map(2)).toStrictEqual('test: 1.4');
+    expect(scale.map(8)).toStrictEqual('test: 2.6');
+    expect(scale.getOptions().range).toStrictEqual(['test: 1', 'test: 3']);
+  });
+
+  test('test nice the domain', () => {
+    const scale = new Sequential({
+      domain: [1.1, 10.9],
+      nice: true,
+    });
+
+    expect(scale.getOptions().domain).toStrictEqual([0, 12]);
+  });
+
+  test('test getTicks()', () => {
+    const scale = new Sequential({
+      domain: [0, 10],
+      interpolator: (t) => 1 - t,
+      round: true,
+    });
+    expect(scale.getTicks()).toStrictEqual([0, 2, 4, 6, 8, 10]);
+
+    scale.update({
+      tickCount: 10,
+    });
+    expect(scale.getTicks()).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  test('test clone', () => {
+    const scale = new Sequential({
+      domain: [0, 10],
+      interpolator: (t) => 1 - t,
+    });
+
+    const newScale = scale.clone();
+    expect(scale.getOptions()).toStrictEqual(newScale.getOptions());
+    expect(scale.getOptions() === newScale.getOptions()).toBeFalsy();
+  });
+});

--- a/docs/api/scales/sequential.md
+++ b/docs/api/scales/sequential.md
@@ -1,0 +1,56 @@
+# Sequential
+
+Sequential scale creates a scale from an interpolator which maps the interval [0, 1] to any arbitrary value.
+
+## Usage
+
+- Basic usage
+
+```ts
+import { Sequential, SequentialOptions } from '@antv/scale';
+
+const scale = new Sequential({
+  domain: [0, 10],
+  interpolator: (t) => 1 - t,
+});
+
+scale.map(0.5); // 0.5
+scale.map(0.2); // 0.8
+scale.map(0.8); // 0.2
+scale.getOptions().range; // [1, 0]
+```
+
+## Options
+
+| Key          | Description                                                                                                                                                                                         | Type                                                    | Default     |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ----------- |
+| domain       | Sets the scale’s domain to the specified array of values.                                                                                                                                           | `number[]`                                              | `[0, 1]`    |
+| unknown      | Sets the output value of the scale for `undefined` (or `NaN`) input values.                                                                                                                         | `any`                                                   | `undefined` |
+| tickCount    | Sets approximately count representative values from the scale’s domain. **The specified `tickCount` in options is only a hint: the scale may return more or fewer values depending on the domain.** | `number`                                                | `5`         |
+| tickMethod   | Sets the method for computing representative values from the scale’s domain.                                                                                                                        | `(min: number, max: number, count: number) => number[]` | `d3-ticks`  |
+| round        | Rounds the output of map or invert if it is true.                                                                                                                                                   | `boolean`                                               | `false`     |
+| clamp        | Constrains the return value of map within the scale’s range if it is true.                                                                                                                          | `boolean`                                               | `false`     |
+| nice         | Extends the domain so that it starts and ends on nice round values if it is true.                                                                                                                   | `boolean`                                               | `false`     |
+| interpolator | Sets the scale’s range interpolator to map the interval [0, 1].                                                                                                                                     | `(t: number) => any`                                    | `(t) => t`  |
+
+## Methods
+
+<a name="sequential_map" href="#sequential_map">#</a> **map**<i>(x: number): number</i>
+
+Given a value in the input domain, returns the corresponding value in the output range if it is not `undefined` (or `NaN`), otherwise `options.unknown`
+
+<a name="sequential_update" href="#sequential_update">#</a> **update**<i>(options: SequentialOptions): void</i>
+
+Updates the scale's options and rescale.
+
+<a name="sequential_get_options" href="#sequential_get_options">#</a> **getOptions**<i>(): SequentialOptions</i>
+
+Returns the scale's current options.
+
+<a name="sequential_clone" href="#sequential_clone">#</a> **clone**<i>(): Sequential</i>
+
+Returns a new Linear scale with the independent and same options as the original one.
+
+<a name="sequential_get_ticks" href="#sequential_get_ticks">#</a> **getTicks**<i>(): number[]</i>
+
+Returns representative values from the scale’s domain computed by specified `options.tickMethod` with `options.tickCount`.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     },
     {
       "path": "dist/scale.min.js",
-      "limit": "30 Kb"
+      "limit": "40 Kb"
     }
   ],
   "author": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { Quantile } from './scales/quantile';
 export { Time } from './scales/time';
 export { Base } from './scales/base';
 export { Continuous } from './scales/continuous';
+export { Sequential } from './scales/sequential';
 
 // tick-methods
 export { d3Ticks } from './tick-methods/d3-ticks';
@@ -39,10 +40,11 @@ export type {
   SqrtOptions,
   QuantileOptions,
   LogOptions,
+  SequentialOptions,
 } from './types';
 
 // others
-export type { TickMethod, Interpolate, Comparator, Interpolates } from './types';
+export type { TickMethod, Interpolate, Comparator, Interpolates, Interpolator } from './types';
 
 // constants
 export {

--- a/src/scales/sequential.ts
+++ b/src/scales/sequential.ts
@@ -1,0 +1,80 @@
+import { identity, isNumber } from '@antv/util';
+import { d3Ticks } from '../tick-methods/d3-ticks';
+import { Interpolator, SequentialOptions } from '../types';
+import { compose } from '../utils';
+import { CreateTransform, Transform } from './continuous';
+import { Linear } from './linear';
+
+// Modify interface exposed by Sequential.
+export interface Sequential {
+  invert: undefined;
+  getOptions(): SequentialOptions;
+  update(updateOptions: Partial<SequentialOptions>): void;
+}
+
+const createInterpolatorRound = (interpolator: Interpolator) => {
+  return (t: number) => {
+    // If result is not number, it can't be rounded.
+    const res = interpolator(t);
+    return isNumber(res) ? Math.round(res) : res;
+  };
+};
+
+const createNormalizeCompose: CreateTransform = (domain) => {
+  const [d0, d1] = domain;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const normalize: Transform = d1 - d0 ? (t: number) => (t - d0) / (d1 - d0) : (_: number) => 0.5;
+  return normalize;
+};
+
+function Sequentialish(Scale) {
+  Scale.prototype.rescale = function () {
+    this.initRange();
+    this.nice();
+    const [transform] = this.chooseTransforms();
+    this.composeOutput(transform, this.chooseClamp(transform));
+  };
+
+  Scale.prototype.initRange = function () {
+    const { interpolator } = this.getOptions();
+    this.options.range = [interpolator(0), interpolator(1)];
+  };
+
+  Scale.prototype.composeOutput = function (transform: Transform, clamp: Transform) {
+    const { domain, interpolator, round } = this.getOptions();
+    const normalize = createNormalizeCompose(domain.map(transform));
+    const interpolate = round ? createInterpolatorRound(interpolator) : interpolator;
+    this.output = compose(interpolate, normalize, clamp, transform);
+  };
+
+  Scale.prototype.invert = undefined;
+}
+
+/**
+ * Sequential 比例尺
+ *
+ * 构造可创建一个在输入和输出之间通过插值函数进行转换的比例尺
+ */
+@Sequentialish
+export class Sequential extends Linear {
+  protected getDefaultOptions(): SequentialOptions {
+    return {
+      domain: [0, 1],
+      unknown: undefined,
+      nice: false,
+      clamp: false,
+      round: false,
+      interpolator: identity,
+      tickMethod: d3Ticks,
+      tickCount: 5,
+    };
+  }
+
+  constructor(options?: SequentialOptions) {
+    super(options);
+  }
+
+  public clone() {
+    return new Sequential(this.options);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,3 +230,9 @@ export type QuantileOptions = {
   /** 计算 ticks 的算法 */
   tickMethod?: TickMethod<number>;
 };
+
+/** 插值器函数 */
+export type Interpolator = (t: number) => any;
+
+/** Sequential 比例尺的选项 */
+export type SequentialOptions = Omit<LinearOptions, 'Interpolates'> & { interpolator?: Interpolator };


### PR DESCRIPTION
### Usage
- [x] source
- [x] test: coverage 100%
- [x] docs

### API 
```ts
import { Sequential, SequentialOptions } from '@antv/scale';

const scale = new Sequential({
  domain: [0, 10],
  interpolator: (t) => 1 - t,
});

scale.map(0.5); // 0.5
scale.map(0.2); // 0.8
scale.map(0.8); // 0.2
scale.getOptions().range; // [1, 0]
```


