### PR TITLE
feat: opt computeBandState & use internMap instead of Map

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     'no-param-reassign': 'off',
     'func-names': ['error', 'never'],
     'no-else-return': 'off',
+    'no-restricted-syntax': 'off',
   },
   settings: {
     'import/parsers': {

--- a/__tests__/unit/scales/band.spec.ts
+++ b/__tests__/unit/scales/band.spec.ts
@@ -219,5 +219,56 @@ describe('band scale', () => {
     expect(bandScale.map('A')).toBe(0);
     expect(bandScale.map('B')).toBeCloseTo(166.67);
     expect(bandScale.map('C')).toBeCloseTo(416.67);
+
+    bandScale.update({
+      range: [0, 300],
+      paddingOuter: 0.2,
+      paddingInner: 0.2,
+      round: true,
+      align: 0.5,
+    });
+    expect(bandScale.map('A')).toBe(19);
+    expect(bandScale.map('B')).toBeCloseTo(112);
+    expect(bandScale.map('C')).toBeCloseTo(243);
+  });
+
+  test('test flex is all 1', () => {
+    const bandScale = new Band({
+      domain: ['A', 'B', 'C'],
+      flex: [1, 1, 1],
+      range: [0, 300],
+    });
+    expect(bandScale.getBandWidth()).toBe(100);
+    expect(bandScale.getStep()).toBe(100);
+  });
+
+  test('test domain length is null', () => {
+    const bandScale = new Band({
+      domain: [],
+      flex: [1, 2, 3],
+      range: [0, 500],
+    });
+    expect(bandScale.getBandWidth()).toBe(1);
+    expect(bandScale.getStep()).toBe(1);
+    expect(bandScale.getRange()).toStrictEqual([]);
+  });
+
+  test('test flex options with object type domain', () => {
+    const time = [new Date(Date.UTC(2022, 9, 5)), new Date(Date.UTC(2022, 9, 6)), new Date(Date.UTC(2022, 9, 7))];
+    const bandScale = new Band({
+      domain: time,
+      flex: [2, 3],
+      range: [0, 500],
+    });
+    expect(bandScale.map(new Date(Date.UTC(2022, 9, 5)))).toBe(0);
+    expect(bandScale.map(new Date(Date.UTC(2022, 9, 6)))).toBeCloseTo(166.67);
+    expect(bandScale.map(new Date(Date.UTC(2022, 9, 7)))).toBeCloseTo(416.67);
+
+    const ba = bandScale.getBandWidth(new Date(Date.UTC(2022, 9, 5)));
+    const bb = bandScale.getBandWidth(new Date(Date.UTC(2022, 9, 6)));
+    const bc = bandScale.getBandWidth(new Date(Date.UTC(2022, 9, 7)));
+    expect([ba, bb, bc].map((d) => d / bc)).toEqual([2, 3, 1]);
+
+    expect(bandScale.getStep(new Date(Date.UTC(2022, 9, 5)))).toBeCloseTo(166.67, 2);
   });
 });

--- a/__tests__/unit/utils/interMap.spec.ts
+++ b/__tests__/unit/utils/interMap.spec.ts
@@ -1,0 +1,32 @@
+import { InternMap } from '../../../src/utils';
+
+describe('create InternMap ', () => {
+  test('create InternMap with key of string', () => {
+    const internMap = new InternMap([
+      [1, 'dog'],
+      [2, 'cat'],
+    ]);
+    internMap.set(3, 'cow');
+    expect(internMap.get(1)).toBe('dog');
+    expect(internMap.get(3)).toBe('cow');
+
+    internMap.set(1, 'mouse');
+    expect(internMap.get(1)).toBe('mouse');
+
+    internMap.delete(2);
+    expect(internMap.has(2)).toBeFalsy();
+  });
+
+  test('create InternMap with key of object', () => {
+    const time1 = new Date(Date.UTC(2022, 9, 5));
+    const time2 = new Date(Date.UTC(2022, 9, 5));
+    expect(time1 === time2).toBeFalsy();
+
+    const internMap = new InternMap([
+      [time1, 'time1'],
+      [time2, 'time2'],
+    ]);
+
+    expect(internMap.get(time1)).toBe('time2');
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,3 +51,4 @@ export {
 } from './utc-interval';
 
 export { chooseNiceTimeMask } from './choose-mask';
+export { InternMap } from './internMap';

--- a/src/utils/internMap.ts
+++ b/src/utils/internMap.ts
@@ -1,0 +1,58 @@
+function internGet({ map, initKey }, value) {
+  const key = initKey(value);
+  return map.has(key) ? map.get(key) : value;
+}
+
+function internSet({ map, initKey }, value) {
+  const key = initKey(value);
+  if (map.has(key)) return map.get(key);
+  map.set(key, value);
+  return value;
+}
+
+function internDelete({ map, initKey }, value) {
+  const key = initKey(value);
+  if (map.has(key)) {
+    value = map.get(key);
+    map.delete(key);
+  }
+  return value;
+}
+
+function keyof(value) {
+  return typeof value === 'object' ? value.valueOf() : value;
+}
+
+/**
+ * @see 参考 https://github.com/mbostock/internmap/blob/main/src/index.js
+ */
+export class InternMap<K, V> extends Map {
+  private map = new Map<K, V>();
+
+  private initKey = keyof;
+
+  constructor(entries) {
+    super();
+    if (entries !== null) {
+      for (const [key, value] of entries) {
+        this.set(key, value);
+      }
+    }
+  }
+
+  get(key: K) {
+    return super.get(internGet({ map: this.map, initKey: this.initKey }, key));
+  }
+
+  has(key: K) {
+    return super.has(internGet({ map: this.map, initKey: this.initKey }, key));
+  }
+
+  set(key: K, value: V) {
+    return super.set(internSet({ map: this.map, initKey: this.initKey }, key), value);
+  }
+
+  delete(key: K) {
+    return super.delete(internDelete({ map: this.map, initKey: this.initKey }, key));
+  }
+}


### PR DESCRIPTION
#### Feature
1. Optmize computeBandState: band scales only do simple calculation if no flex option.
2. Use InternMap instead of Map to deal with the key of the object type.

#### Relation Issue
#193 