### PR TITLE
fix(ordinal): update map only with unset unknown

### DIFF
--- a/__tests__/unit/scales/band.spec.ts
+++ b/__tests__/unit/scales/band.spec.ts
@@ -115,9 +115,9 @@ describe('band scale', () => {
     expect(bandScale.map('wow')).toStrictEqual(0);
 
     bandScale.update({
-      unknown: 'hello world~',
+      unknown: null,
     });
-    expect(bandScale.map('bar')).toStrictEqual('hello world~');
+    expect(bandScale.map('bar')).toStrictEqual(null);
   });
 
   test('test padding option', () => {

--- a/__tests__/unit/scales/ordinal.spec.ts
+++ b/__tests__/unit/scales/ordinal.spec.ts
@@ -1,11 +1,12 @@
 import { Ordinal, Comparator } from '../../../src';
+import { defaultUnknown } from '../../../src/scales/ordinal';
 
 describe('ordinal scale', () => {
-  test('ordinal has no expected defaults', () => {
+  test('ordinal has expected defaults', () => {
     const c = new Ordinal();
     expect(c.getOptions().domain).toStrictEqual([]);
     expect(c.getOptions().range).toStrictEqual([]);
-    expect(c.getOptions().unknown).toBeUndefined();
+    expect(c.getOptions().unknown).toBe(defaultUnknown);
   });
 
   test('default options', () => {
@@ -42,7 +43,7 @@ describe('ordinal scale', () => {
 
     // 不存在的值 我们将新值插入 domain 中，并更新 map
     expect(scale.map('3')).toStrictEqual('February');
-    expect(scale.getOptions().domain.length).toStrictEqual(6);
+    expect(scale.getOptions().domain?.length).toStrictEqual(6);
 
     // NaN / undefined / null 做法同上
     expect(scale.map(NaN)).toStrictEqual('January');
@@ -147,10 +148,10 @@ describe('ordinal scale', () => {
     });
     expect(scale.map('D')).toStrictEqual('a');
     scale.update({
-      unknown: 'hello world',
+      unknown: null,
     });
-    expect(scale.map('E')).toStrictEqual('hello world');
-    expect(scale.invert('foo')).toStrictEqual('hello world');
+    expect(scale.map('E')).toStrictEqual(null);
+    expect(scale.invert('foo')).toStrictEqual(null);
   });
 
   test('duplicate data in domain or range', () => {

--- a/src/scales/band.ts
+++ b/src/scales/band.ts
@@ -1,6 +1,6 @@
 import { InternMap } from '../utils';
 import { BandOptions, Domain } from '../types';
-import { Ordinal } from './ordinal';
+import { Ordinal, defaultUnknown } from './ordinal';
 
 function normalize(array: number[]): number[] {
   const min = Math.min(...array);
@@ -216,7 +216,7 @@ export class Band<O extends BandOptions = BandOptions> extends Ordinal<O> {
       paddingInner: 0,
       paddingOuter: 0,
       padding: 0,
-      unknown: undefined,
+      unknown: defaultUnknown,
       flex: [],
     } as O;
   }

--- a/src/scales/ordinal.ts
+++ b/src/scales/ordinal.ts
@@ -16,6 +16,8 @@ type MapBetweenArrOptions = {
   notFoundReturn?: any;
 };
 
+export const defaultUnknown = Symbol('defaultUnknown');
+
 /**
  * 更新 indexMap
  *
@@ -42,9 +44,11 @@ function mapBetweenArrByMapIndex(options: MapBetweenArrOptions) {
   const { value, from, to, mapper, notFoundReturn } = options;
   let mappedIndex = mapper.get(value);
 
-  // index 不存在时，我们将 value 添加到原数组, 并更新 Map
+  // index 不存在时，
+  // 如果用户显式设置了 unknown 的值，那么就返回 unknown 的值
+  // 否者我们将 value 添加到原数组, 并更新 Map
   if (mappedIndex === undefined) {
-    if (notFoundReturn) {
+    if (notFoundReturn !== defaultUnknown) {
       return notFoundReturn;
     }
     mappedIndex = from.push(value) - 1;
@@ -91,6 +95,7 @@ export class Ordinal<O extends OrdinalOptions = OrdinalOptions> extends Base<O> 
     return {
       domain: [],
       range: [],
+      unknown: defaultUnknown,
     } as O;
   }
 

--- a/src/scales/point.ts
+++ b/src/scales/point.ts
@@ -1,4 +1,5 @@
 import { Band } from './band';
+import { defaultUnknown } from './ordinal';
 import { PointOptions, BandOptions } from '../types';
 
 /**
@@ -29,7 +30,7 @@ export class Point extends Band<PointOptions & BandOptions> {
       align: 0.5,
       round: false,
       padding: 0,
-      unknown: undefined,
+      unknown: defaultUnknown,
       paddingInner: 1,
       paddingOuter: 0,
     };


### PR DESCRIPTION
当 ordinal, band, point scale 比例尺显示设置了 unknown 的时候，不管该 unknown 是否是 falsy，都将不在 domain 的值映射为设置的 unknown，而不是将其添加进 indexMap。

```js
// 修复之前
const scale = new Ordinal({
  domain: ['a'],
  range: ['A'],
  unknown: null
});

scale.map('b'); // 'A'
```
```js
// 修复之后
const scale = new Ordinal({
  domain: ['a'],
  range: ['A'],
  unknown: null
});

scale.map('b'); // null
```