### PR TITLE
fix(ticks): optimize log ticks

### DIFF
--- a/__tests__/unit/tick-methods/d3-log.spec.ts
+++ b/__tests__/unit/tick-methods/d3-log.spec.ts
@@ -35,6 +35,11 @@ describe('d3Log', () => {
     expect(d3Log(286.9252014, 329.4978332, 10)).toEqual([290, 295, 300, 305, 310, 315, 320, 325]);
   });
 
+  test('d3Log(a, b, -1) generates auto count tick', () => {
+    expect(d3Log(0.001, 1, -1)).toEqual([0.001, 0.01, 0.1, 1]);
+    expect(d3Log(1, 100, -1)).toEqual([1, 10, 100]);
+  });
+
   test('d3Log(a, b, n) generates linear ticks when the domain extent is small', () => {
     expect(d3Log(41, 42, 10)).toEqual([41, 41.1, 41.2, 41.3, 41.4, 41.5, 41.6, 41.7, 41.8, 41.9, 42]);
     expect(d3Log(42, 41, 10)).toEqual([42, 41.9, 41.8, 41.7, 41.6, 41.5, 41.4, 41.3, 41.2, 41.1, 41]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/scale",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Toolkit for mapping abstract data into visual representation.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,6 @@ module.exports = [
       format: 'umd',
       sourcemap: false,
     },
-    plugins: [resolve(), typescript(), commonjs(), uglify()],
+    plugins: [resolve(), commonjs(), typescript(), uglify()],
   },
 ];

--- a/src/tick-methods/d3-log.ts
+++ b/src/tick-methods/d3-log.ts
@@ -1,6 +1,6 @@
 import { TickMethod } from '../types';
 import { d3Ticks } from './d3-ticks';
-import { pows, logs } from '../utils';
+import { pows, logs, prettyNumber } from '../utils';
 
 export const d3Log: TickMethod = (a, b, n, base = 10) => {
   const shouldReflect = a < 0;
@@ -39,7 +39,10 @@ export const d3Log: TickMethod = (a, b, n, base = 10) => {
     }
     if (ticks.length * 2 < n) ticks = d3Ticks(min, max, n);
   } else {
-    ticks = d3Ticks(i, j, Math.min(j - i, n)).map(pow);
+    i = prettyNumber(i);
+    j = prettyNumber(j);
+    const count = n === -1 ? j - i : Math.min(j - i, n);
+    ticks = d3Ticks(i, j, count).map(pow);
   }
 
   return r ? ticks.reverse() : ticks;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,6 +16,7 @@ export {
   createInterpolateNumber,
   createInterpolateColor,
 } from './interpolate';
+export { prettyNumber } from './pretty-number';
 
 export {
   DURATION_SECOND,


### PR DESCRIPTION
# 优化 d3-log-ticks

背景：https://github.com/antvis/scale/issues

## 存在问题

1. 存在误差：

```js
ticks(0.001, 1, 2);

// expect: [0.001, 0.01, 0.1, 1]
// actual: [0.01, 0.1, 1]
```
计算 tick 会对最小值和最大值求指数范围，然后基于该范围生成 tick，但是求指数的时候存在误差：

```js
Math.log(0.001) / Math.log(10); 

// expect: -3
// actual: -29999...8
```
所以实际生成的 tick 是 `[10 ^ -2, 10 ^ -1, 10 ^ 0]` 为 `[0.01, 0.001, 1]`

2. 冗余 tick

当 tickCount 大于最小值和最大值求指数范围距离之后，会在中间插入更多的 tick，导致 tick 很多。这么做的目的是让 tickCount 生效的情况，保证刻度的可读性。但是对于 log 比例尺，大部分情况应该不要用用户自己去指定 tickCount，而是按照指数递增生成。

```js
ticks(0.001, 1, 10);

// expect: [0.001, 0.01, 0.1, 1]
// actual: [0.001, 0.002, ...., 0.009, 0.1, 0.2, ....0.9, 1]
```

## 解决办法

1. 存在误差：通过 `prettryNumber` 方法格式化数据
2. 冗余 tick：当设置 tickCount 为 -1 的时候，自动计算 tick。

```js
ticks(0.001, 1, -1); // [0.001, 0.01, 0.1, 1]
```

## 未来工作

当 scale 发版本之后，G2 log scale 的 tickCount 默认值应该为 -1，这样可以解决这个 issue 里面的问题：https://github.com/antvis/G2/issues/4867

