### PR TITLE
refactor(ticks): calc pow more precisely

### DIFF
--- a/src/tick-methods/d3-log.ts
+++ b/src/tick-methods/d3-log.ts
@@ -1,6 +1,6 @@
 import { TickMethod } from '../types';
 import { d3Ticks } from './d3-ticks';
-import { pows, logs, prettyNumber } from '../utils';
+import { pows, logs } from '../utils';
 
 export const d3Log: TickMethod = (a, b, n, base = 10) => {
   const shouldReflect = a < 0;
@@ -39,8 +39,6 @@ export const d3Log: TickMethod = (a, b, n, base = 10) => {
     }
     if (ticks.length * 2 < n) ticks = d3Ticks(min, max, n);
   } else {
-    i = prettyNumber(i);
-    j = prettyNumber(j);
     const count = n === -1 ? j - i : Math.min(j - i, n);
     ticks = d3Ticks(i, j, count).map(pow);
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,7 +16,6 @@ export {
   createInterpolateNumber,
   createInterpolateColor,
 } from './interpolate';
-export { prettyNumber } from './pretty-number';
 
 export {
   DURATION_SECOND,

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -4,7 +4,14 @@ const reflect = (f: Function) => {
 
 export const logs = (base: number, shouldReflect: boolean) => {
   const baseCache = Math.log(base);
-  const log = base === Math.E ? Math.log : (x: number) => Math.log(x) / baseCache;
+  const log =
+    base === Math.E
+      ? Math.log
+      : base === 10
+      ? Math.log10
+      : base === 2
+      ? Math.log2
+      : (x: number) => Math.log(x) / baseCache;
   return shouldReflect ? reflect(log) : log;
 };
 


### PR DESCRIPTION
优化计算指数的方法，之前是根据换底公式计算：会存在误差，现在使用 Math 内置的一些计算对数的方法代替：`Math.log10`，`Math.log2`。

```js
Math.log(0.001) / Math.log(10); // -2.999...8
Math.log10(0.001); // -3
```