### PR TITLE
fix: fix floating point precision bug

### DIFF
--- a/__tests__/unit/tick-methods/r-pretty.spec.ts
+++ b/__tests__/unit/tick-methods/r-pretty.spec.ts
@@ -67,7 +67,9 @@ describe('rPretty ticks', () => {
   });
 
   it('rPretty for tiny number', () => {
-    expect(rPretty(9.899999999999999, 9.9)).toStrictEqual([9.899999999999999, 9.899999999999999, 9.9, 9.9]);
+    expect(rPretty(9.89999999999999, 9.9)).toStrictEqual([
+      9.89999999999999, 9.89999999999999, 9.89999999999999, 9.89999999999999, 9.9, 9.9, 9.9,
+    ]);
   });
 
   it('handle decimal tickCount', () => {

--- a/__tests__/unit/utils/pretty-number.spec.ts
+++ b/__tests__/unit/utils/pretty-number.spec.ts
@@ -7,6 +7,7 @@ describe('prettyNumber', () => {
     expect(prettyNumber(0.1 + 0.2)).toBe(0.3);
     expect(prettyNumber(-1e-16)).toBe(-1e-16);
     expect(prettyNumber(-0.09999999999999998)).toBe(-0.1);
+    expect(prettyNumber(-4.3999999999999995)).toBe(-4.4);
     expect(prettyNumber(-(0.1 + 0.2))).toBe(-0.3);
   });
 });

--- a/src/utils/pretty-number.ts
+++ b/src/utils/pretty-number.ts
@@ -1,4 +1,4 @@
 // 为了解决 js 运算的精度问题
 export function prettyNumber(n: number) {
-  return Math.abs(n) < 1e-15 ? n : parseFloat(n.toFixed(15));
+  return Math.abs(n) < 1e-14 ? n : parseFloat(n.toFixed(14));
 }


### PR DESCRIPTION
#205 

修复浮点数精确度的问题

![image](https://github.com/antvis/scale/assets/16484068/fb8c6828-3f3f-4e99-af86-c6ad20ae1310)

以上情况表面上是5结尾，但是 `toFixed` 的时候因为实际值更偏向 `4671` 结尾所以会舍弃掉最后一位