### PR TITLE
fix(band): fix: avoid stack overflow in normalize by replacing Math.m…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,28 +9,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v3
         with:
           node-version: '12'
 
       - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
+        uses: actions/cache@v4
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            cache-node-modules-
+            ${{ runner.os }}-build-cache-node-modules-
+
+      - name: Install dependencies
+        run: npm install
 
       - name: Run ci
-        run: |
-          npm install
-          npm run ci
-      - name: coverall
+        run: npm run ci
+
+      - name: Upload coverage to Coveralls
         if: success()
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
 

--- a/__tests__/unit/scales/band.spec.ts
+++ b/__tests__/unit/scales/band.spec.ts
@@ -52,6 +52,18 @@ describe('band scale', () => {
     expect(opt.domain).toStrictEqual(['one', 'two', 'three', 'four']);
   });
 
+  test('test band with huge domain (1000000)', () => {
+    const N = 1000000;
+    const domain = Array.from({ length: N }, (_, i) => `Item${i}`);
+    const flex = Array(N).fill(1);
+    const range = [0, N];
+
+    const bandScale = new Band({ domain, flex, range });
+
+    expect(bandScale.map('Item0')).toBeCloseTo(0, 5);
+    expect(bandScale.map(`Item${N - 1}`)).toBeCloseTo(N - (range[1] - range[0]) / N, 5);
+  });
+
   test('test padding-inner option', () => {
     const bandScale = new Band({
       domain: ['A', 'B', 'C'],

--- a/src/scales/band.ts
+++ b/src/scales/band.ts
@@ -3,7 +3,9 @@ import { BandOptions, Domain } from '../types';
 import { Ordinal, defaultUnknown } from './ordinal';
 
 function normalize(array: number[]): number[] {
-  const min = Math.min(...array);
+  if (array.length === 0) return [];
+
+  const min = array.reduce((a, b) => (a < b ? a : b));
   return array.map((d) => d / min);
 }
 

--- a/src/scales/band.ts
+++ b/src/scales/band.ts
@@ -3,10 +3,8 @@ import { BandOptions, Domain } from '../types';
 import { Ordinal, defaultUnknown } from './ordinal';
 
 function normalize(array: number[]): number[] {
-  if (array.length === 0) return [];
-
-  const min = array.reduce((a, b) => (a < b ? a : b));
-  return array.map((d) => d / min);
+  const min = array.reduce((a, b) => Math.min(a, b), Infinity);
+  return min === Infinity ? [] : array.map((d) => d / min);
 }
 
 function splice(array: number[], n: number) {


### PR DESCRIPTION
# 优化 normalize 函数，避免大数组栈溢出并提升可读性

## 变更描述

重构 `normalize` 函数，解决两个问题：
1. **修复潜在栈溢出**：原实现 `Math.min(...array)` 在大数组时可能超出 JS 引擎参数限制
2. **增强鲁棒性**：显式处理空数组情况，避免 `reduce` 报错


## 参考文档
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max#getting_the_maximum_element_of_an_array
