### PR TITLE
fix: tick计算精度问题

### DIFF
--- a/__tests__/unit/tick-methods/d3-ticks.spec.ts
+++ b/__tests__/unit/tick-methods/d3-ticks.spec.ts
@@ -29,4 +29,8 @@ describe('d3 ticks', () => {
     expect(fn(0, 5, -1)).toStrictEqual(fn(0, 5, 0));
     expect(fn(0, 5, -1.2)).toStrictEqual(fn(0, 5, 0));
   });
+
+  test('maximum value accuracy', () => {
+    expect(fn(0.53, 0.58, 6)).toStrictEqual([0.53, 0.54, 0.55, 0.56, 0.57, 0.58]);
+  });
 });

--- a/src/tick-methods/d3-ticks.ts
+++ b/src/tick-methods/d3-ticks.ts
@@ -42,7 +42,8 @@ export const d3Ticks: TickMethod = (begin: number, end: number, count: number, b
   } else {
     step = -step;
     start = Math.ceil(start * step);
-    stop = Math.floor(stop * step);
+    // 1e-10: Math.floor(0.58 * 100) => 57
+    stop = Math.floor(stop * step + 1e-10);
     ticks = new Array((n = Math.ceil(stop - start + 1)));
     for (let i = 0; i < n; i += 1) {
       ticks[i] = (start + i) / step;


### PR DESCRIPTION
## 刻度计算精度问题

解决` Math.floow(0.58 * 100)` 结果为 `57` 之类的问题，最终会导致图表少一条刻度线
